### PR TITLE
Fix for allowing correct interaction with django-admin-enhancer.

### DIFF
--- a/polymorphic/admin.py
+++ b/polymorphic/admin.py
@@ -247,10 +247,12 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
 
         # Patch the change URL so it's not a big catch-all; allowing all custom URLs to be added to the end.
         # The url needs to be recreated, patching url.regex is not an option Django 1.4's LocaleRegexProvider changed it.
-        new_change_url = url(r'^(\d+)/$', self.admin_site.admin_view(self.change_view), name='{0}_{1}_change'.format(*info))
+        name='{0}_{1}_change'.format(*info)
         for i, oldurl in enumerate(urls):
-            if oldurl.name == new_change_url.name:
+            if oldurl.name == name:
+                new_change_url = url(oldurl.regex.pattern, self.admin_site.admin_view(self.change_view), name=name)
                 urls[i] = new_change_url
+                break
 
         # Define the catch-all for custom views
         custom_urls = patterns('',


### PR DESCRIPTION
Make sure to use the same regex pattern as the oldurl we are replacing.
