### PR TITLE
[Admin] Fully supports related fields (fk, m2m, 1to1, genericfk) to chil...

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -21,7 +21,7 @@ The parent model
 The parent model needs to inherit ``PolymorphicParentModelAdmin``, and implement the following:
 
 * ``base_model`` should be set
-* ``child_models`` or ``get_child_models()`` should return a list
+* ``child_models`` or ``get_child_models()`` should return an iterable
   of Model classes.
 
 The exact implementation can depend on the way your module is structured.

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -14,7 +14,6 @@ The polymorphic admin is implemented via a parent admin that forwards the *edit*
 to the ``ModelAdmin`` of the derived child model. The *list* page is still implemented by the parent model admin.
 
 Both the parent model and child model need to have a ``ModelAdmin`` class.
-Only the ``ModelAdmin`` class of the parent/base model has to be registered in the Django admin site.
 
 The parent model
 ----------------
@@ -22,7 +21,8 @@ The parent model
 The parent model needs to inherit ``PolymorphicParentModelAdmin``, and implement the following:
 
 * ``base_model`` should be set
-* ``child_models`` or ``get_child_models()`` should return a list with (Model, ModelAdmin) tuple.
+* ``child_models`` or ``get_child_models()`` should return a list
+  of Model classes.
 
 The exact implementation can depend on the way your module is structured.
 For simple inheritance situations, ``child_models`` is the best solution.
@@ -66,6 +66,10 @@ The models are taken from :ref:`advanced-features`.
     from polymorphic.admin import PolymorphicParentModelAdmin, PolymorphicChildModelAdmin
     from .models import ModelA, ModelB, ModelC
 
+    class ModelAParentAdmin(PolymorphicParentModelAdmin):
+        """ The parent model admin """
+        base_model = ModelA
+        child_models = (ModelB, ModelC)
 
     class ModelAChildAdmin(PolymorphicChildModelAdmin):
         """ Base admin class for all child models """
@@ -77,21 +81,14 @@ The models are taken from :ref:`advanced-features`.
         base_fieldsets = (
             ...
         )
+        # Define other common features between the child model admins here
 
     class ModelBAdmin(ModelAChildAdmin):
-        # define custom features here
+        # Define custom features here
 
     class ModelCAdmin(ModelBAdmin):
-        # define custom features here
+        # Define custom features here
 
-
-    class ModelAParentAdmin(PolymorphicParentModelAdmin):
-        """ The parent model admin """
-        base_model = ModelA
-        child_models = (
-            (ModelB, ModelBAdmin),
-            (ModelC, ModelCAdmin),
-        )
-
-    # Only the parent needs to be registered:
     admin.site.register(ModelA, ModelAParentAdmin)
+    admin.site.register(ModelB, ModelBAdmin)
+    admin.site.register(ModelC, ModelCAdmin)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,43 @@
 Changelog
 ==========
 
+
+Version 0.6
+-----------
+
+* Admin integration has been simplified.  It became less hacky and therefore
+  fixed lots of issues.
+* Admin integration of a foreign key to a child polymorphic model is fully
+  working.
+* Full django-grappelli compatibility.
+* **Changed** ``PolymorphicParentModelAdmin.child_models`` is now a tuple
+  of Models.  Before it was a tuple of (Model, ModelAdmin) tuples.
+* **Changed** Child models now have to be registered to the admin site.
+
+If you already use the admin integration, you therefore have to:
+
+* Change
+
+  .. code-block:: python
+
+      child_models = ((ModelA, ModelAChildAdmin), (ModelB, ModelBChildAdmin))
+
+  to
+
+  .. code-block:: python
+
+      child_models = (ModelA, ModelB)
+
+* Register the child models in the classical way:
+
+  .. code-block:: python
+
+      admin.site.register(ModelA, ModelAChildAdmin)
+      admin.site.register(ModelB, ModelBChildAdmin)
+
+See :ref:`the admin example <admin-example>` for more details.
+
+
 Version 0.5.4 (in development)
 ------------------------------
 

--- a/polymorphic/admin.py
+++ b/polymorphic/admin.py
@@ -154,10 +154,6 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
         if model_class not in self._child_models:
             raise PermissionDenied("Invalid model '{0}', it must be registered as child model.".format(model_class))
 
-        return self._simple_get_real_admin_by_model(model_class)
-
-
-    def _simple_get_real_admin_by_model(self, model_class):
         try:
             # HACK: the only way to get the instance of an model admin,
             # is to read the registry of the AdminSite.


### PR DESCRIPTION
...d models.

This fixes #46, #47, and perhaps #57.
This also fixes some issues with grappelli related lookups.

WARNING: This changes the syntax of the admin integration.

There was no option but to change the syntax.  I tried keeping the same syntax and it was not working because while the admin site registry was iterated by Django, the size of the registry changed because of the lazy setup.  The only solution was to stick to the classical Django syntax.
