### PR TITLE
Allow PolymorphicQuerySet.instance_of to accept strings.

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -86,12 +86,11 @@ class PolymorphicQuerySet(QuerySet):
                     # If it can't be split, assume it's in the current app.
                     app_label = self.model._meta.app_label
                     model_name = model
-            else:
-                # It's a model class
-                app_label = model._meta.app_label
-                model_name = model._meta.object_name
 
-            model = get_model(app_label, model_name)
+                model = get_model(app_label, model_name)
+                if not model:
+                    raise ValueError("Cannot load '%s.%s'." % (app_label, model_name))
+
             model_objects += [model]
 
         return model_objects


### PR DESCRIPTION
The interface is similar to passing strings into ForeignKey and helps resolve circular dependencies.

I can add tests and docs later but I wanted to get feedback on the approach first. I had originally put it in [`_create_model_filter_Q`](https://github.com/chrisglass/django_polymorphic/blob/master/polymorphic/query_translate.py#L213-L248) but you lose the "app label" awareness from the instance that allows you to pass in `ModelName` (as opposed to `app_label.ModelName`).
