### PR TITLE
Test in development Django version (with allow failures)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,51 +7,56 @@ python:
   - "3.4"
   - "3.5"
 env:
-  - DJANGO=">=1.4,<1.5"
-  - DJANGO=">=1.5,<1.6"
-  - DJANGO=">=1.6,<1.7"
-  - DJANGO=">=1.7,<1.8"
-  - DJANGO=">=1.8,<1.9"
-  - DJANGO=">=1.9,<1.10"
+  - DJANGO="Django>=1.4,<1.5"
+  - DJANGO="Django>=1.5,<1.6"
+  - DJANGO="Django>=1.6,<1.7"
+  - DJANGO="Django>=1.7,<1.8"
+  - DJANGO="Django>=1.8,<1.9"
+  - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="https://github.com/django/django/tarball/master"
 
 matrix:
   exclude:
   - python: "3.5"
-    env: DJANGO=">=1.4,<1.5"
+    env: DJANGO="Django>=1.4,<1.5"
   - python: "3.5"
-    env: DJANGO=">=1.5,<1.6"
+    env: DJANGO="Django>=1.5,<1.6"
   - python: "3.5"
-    env: DJANGO=">=1.6,<1.7"
+    env: DJANGO="Django>=1.6,<1.7"
   - python: "3.5"
-    env: DJANGO=">=1.7,<1.8"
+    env: DJANGO="Django>=1.7,<1.8"
 
   - python: "3.4"
-    env: DJANGO=">=1.4,<1.5"
+    env: DJANGO="Django>=1.4,<1.5"
   - python: "3.4"
-    env: DJANGO=">=1.9,<1.10"
+    env: DJANGO="Django>=1.9,<1.10"
 
   - python: "3.3"
-    env: DJANGO=">=1.4,<1.5"
+    env: DJANGO="Django>=1.4,<1.5"
   - python: "3.3"
-    env: DJANGO=">=1.9,<1.10"
+    env: DJANGO="Django>=1.9,<1.10"
 
   - python: "3.2"
-    env: DJANGO=">=1.4,<1.5"
+    env: DJANGO="Django>=1.4,<1.5"
   - python: "3.2"
-    env: DJANGO=">=1.9,<1.10"
+    env: DJANGO="Django>=1.9,<1.10"
 
   - python: "2.6"
-    env: DJANGO=">=1.7,<1.8"
+    env: DJANGO="Django>=1.7,<1.8"
   - python: "2.6"
-    env: DJANGO=">=1.8,<1.9"
+    env: DJANGO="Django>=1.8,<1.9"
   - python: "2.6"
-    env: DJANGO=">=1.9,<1.10"
+    env: DJANGO="Django>=1.9,<1.10"
+  - python: "2.6"
+    env: DJANGO="https://github.com/django/django/tarball/master"
+  allow_failures:
+    - env: DJANGO="https://github.com/django/django/tarball/master"
 
 before_install:
 - pip install codecov
 
 install:
-  - pip install django$DJANGO coverage==3.6
+  - pip install -q $DJANGO coverage==3.6
 
 script:
   - coverage run --source=polymorphic runtests.py

--- a/runtests.py
+++ b/runtests.py
@@ -18,6 +18,16 @@ sys.stderr.write('Using Django version {0} from {1}\n'.format(
 )
 
 if not settings.configured:
+    context_processors = [
+        'django.contrib.auth.context_processors.auth',
+        'django.template.context_processors.debug',
+        'django.template.context_processors.i18n',
+        'django.template.context_processors.media',
+        'django.template.context_processors.static',
+        'django.template.context_processors.tz',
+        'django.contrib.messages.context_processors.messages',
+        'django.core.context_processors.request',
+    ]
     settings.configure(
         DEBUG=True,
         TEMPLATE_DEBUG=True,
@@ -34,13 +44,17 @@ if not settings.configured:
         TEMPLATE_LOADERS=(
             'django.template.loaders.app_directories.Loader',
         ),
-        TEMPLATE_CONTEXT_PROCESSORS=(
-            # list() is only needed for older versions of django where this is
-            # a tuple:
-            list(default_settings.TEMPLATE_CONTEXT_PROCESSORS) + [
-                'django.core.context_processors.request',
-            ]
-        ),
+        TEMPLATE_CONTEXT_PROCESSORS=context_processors,
+        TEMPLATES = [
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': [],
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    'context_processors': context_processors,
+                },
+            },
+        ],
         TEST_RUNNER = 'django.test.runner.DiscoverRunner' if django.VERSION >= (1, 7) else 'django.test.simple.DjangoTestSuiteRunner',
         INSTALLED_APPS = (
             'django.contrib.auth',


### PR DESCRIPTION
This patch runs enables Travis tests in Django development (with allow failures) to show the errors of current codebase with Django 1.10 (i.e. #225).
It also contains correction for new templates handling in tests in Django 1.10