### PR TITLE
Update docs: Admin child_models are (Model, ModelAdmin) pairs

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -90,7 +90,10 @@ The models are taken from :ref:`advanced-features`.
     class ModelAParentAdmin(PolymorphicParentModelAdmin):
         """ The parent model admin """
         base_model = ModelA
-        child_models = (ModelB, ModelC)
+        child_models = (
+            (ModelB, ModelBAdmin), 
+            (ModelC, ModelCAdmin),
+        )
         list_filter = (PolymorphicChildModelFilter,)  # This is optional.
 
 


### PR DESCRIPTION
If users follow the documentation, they'll run into issue #227 (like I did).