### PR TITLE
CSS tweak for Grappelli

### DIFF
--- a/polymorphic/static/polymorphic/css/polymorphic_inlines.css
+++ b/polymorphic/static/polymorphic/css/polymorphic_inlines.css
@@ -1,5 +1,6 @@
 .polymorphic-add-choice {
   position: relative;
+  clear: left;
 }
 
 .polymorphic-add-choice a:focus {


### PR DESCRIPTION
Prevent div.polymorphic-add-choice overlapping previous inline formset when using Grappelli.

Also tested without Grappelli.

<img width="1672" alt="screen shot 2016-09-03 at 15 17 53" src="https://cloud.githubusercontent.com/assets/2640227/18225450/b02f3296-71e9-11e6-8725-d9a7634f17d4.png">
