### PR TITLE
Wrap call to key() in list() so it can be indexed

### DIFF
--- a/polymorphic/formsets/models.py
+++ b/polymorphic/formsets/models.py
@@ -180,7 +180,7 @@ class BasePolymorphicModelFormSet(BaseModelFormSet):
                 # Extra forms, cycle between all types
                 # TODO: take the 'extra' value of each child formset into account.
                 total_known = len(self.queryset_data)
-                child_models = self.child_forms.keys()
+                child_models = list(self.child_forms.keys())
                 model = child_models[(i - total_known) % len(child_models)]
 
         form_class = self.get_form_class(model)


### PR DESCRIPTION
In Python 3.4 trying to generate a polymorphic_inlineformset results in a TypeError with the following message: "'KeysView' object does not support indexing". This solves that problem by ensuring that `child_models` is a list, and thus can be referenced by index.