### PR TITLE
Install django.contrib.contenttypes for docstrings.

### DIFF
--- a/docs/_ext/djangodummy/settings.py
+++ b/docs/_ext/djangodummy/settings.py
@@ -9,3 +9,7 @@ STATIC_URL = '/static/'
 
 # Avoid error for missing the secret key
 SECRET_KEY = 'docs'
+
+INSTALLED_APPS = [
+    'django.contrib.contenttypes',
+]


### PR DESCRIPTION
This is merely cosmetic to avoid Django warning because of
`django.contrib.contenttypes` being referenced but not an installed app.