### PR TITLE
Test against django 1.11(b1) / python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 env:
   - DJANGO="Django>=1.4,<1.5"
   - DJANGO="Django>=1.5,<1.6"
@@ -16,10 +17,26 @@ env:
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
+  - DJANGO="Django==1.11b1"
   - DJANGO="https://github.com/django/django/tarball/master"
 
 matrix:
   exclude:
+  - python: "3.6"
+    env: DJANGO="Django>=1.4,<1.5"
+  - python: "3.6"
+    env: DJANGO="Django>=1.5,<1.6"
+  - python: "3.6"
+    env: DJANGO="Django>=1.6,<1.7"
+  - python: "3.6"
+    env: DJANGO="Django>=1.7,<1.8"
+  - python: "3.6"
+    env: DJANGO="Django>=1.8,<1.9"
+  - python: "3.6"
+    env: DJANGO="Django>=1.9,<1.10"
+  - python: "3.6"
+    env: DJANGO="Django>=1.10,<1.11"
+
   - python: "3.5"
     env: DJANGO="Django>=1.4,<1.5"
   - python: "3.5"
@@ -43,6 +60,8 @@ matrix:
   - python: "3.3"
     env: DJANGO="Django>=1.10,<1.11"
   - python: "3.3"
+    env: DJANGO="Django==1.11b1"
+  - python: "3.3"
     env: DJANGO="https://github.com/django/django/tarball/master"
 
   - python: "3.2"
@@ -51,6 +70,8 @@ matrix:
     env: DJANGO="Django>=1.9,<1.10"
   - python: "3.2"
     env: DJANGO="Django>=1.10,<1.11"
+  - python: "3.2"
+    env: DJANGO="Django==1.11b1"
   - python: "3.2"
     env: DJANGO="https://github.com/django/django/tarball/master"
 
@@ -62,6 +83,8 @@ matrix:
     env: DJANGO="Django>=1.9,<1.10"
   - python: "2.6"
     env: DJANGO="Django>=1.10,<1.11"
+  - python: "2.6"
+    env: DJANGO="Django==1.11b1"
   - python: "2.6"
     env: DJANGO="https://github.com/django/django/tarball/master"
   allow_failures:

--- a/polymorphic/tests/__init__.py
+++ b/polymorphic/tests/__init__.py
@@ -196,6 +196,7 @@ if django.VERSION >= (1, 7):
 
 class MROBase1(ShowFieldType, PolymorphicModel):
     objects = MyManager()
+    base_1_id = models.AutoField(primary_key=True)
     field1 = models.CharField(max_length=10)  # needed as MyManager uses it
 
 
@@ -204,6 +205,7 @@ class MROBase2(MROBase1):
 
 
 class MROBase3(models.Model):
+    base_3_id = models.AutoField(primary_key=True)
     objects = PolymorphicManager()
 
 

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -360,7 +360,11 @@ class PolymorphicTests(TestCase):
         # no pretty printing
         ModelShow1_plain.objects.create(field1='abc')
         ModelShow2_plain.objects.create(field1='abc', field2='def')
-        self.assertEqual(qrepr(ModelShow1_plain.objects.all()), '<QuerySet [<ModelShow1_plain: ModelShow1_plain object>, <ModelShow2_plain: ModelShow2_plain object>]>')
+        # repr classnames are not hardcoded in Django 1.11+
+        if django.VERSION >= (1, 11):
+            self.assertEqual(qrepr(ModelShow1_plain.objects.all()), '<PolymorphicQuerySet [<ModelShow1_plain: ModelShow1_plain object>, <ModelShow2_plain: ModelShow2_plain object>]>')
+        else:
+            self.assertEqual(qrepr(ModelShow1_plain.objects.all()), '<QuerySet [<ModelShow1_plain: ModelShow1_plain object>, <ModelShow2_plain: ModelShow2_plain object>]>')
 
     def test_extra_method(self):
         self.create_model2abcd()

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist=
     py26-django{14,15,16},
-    py27-django{14,15,16,17,18,19,110},
+    py27-django{14,15,16,17,18,19,110,111},
     py32-django{15,16,17,18},
     py33-django{15,16,17,18},
-    py34-django{15,16,17,18,19,110},
-    py35-django{18,19,110}
+    py34-django{15,16,17,18,19,110,111},
+    py35-django{18,19,110,111},
+    py36-django{111},
     # py33-django-dev,
     docs,
 
@@ -18,6 +19,7 @@ deps =
     django18: Django >= 1.8, < 1.9
     django19: Django >= 1.9, < 1.10
     django110: Django >= 1.10, < 1.11
+    django111: Django == 1.11b1
     django-dev: https://github.com/django/django/tarball/master
 commands=
     python runtests.py


### PR DESCRIPTION
This builds django-polymorphic against python 3.6 and django 1.11b1.

The new version of python works fine, but django 1.11 fails.

~~The test suite now runs checks, and it seems to be failing on one of them:~~
~~`polymorphic.MRODerived: (models.E005) The field 'id' from parent model 'polymorphic.mrobase3' clashes with the field 'id' from parent model 'polymorphic.mrobase1'.`~~ 
~~Once that's addressed, I suspect we're going to get a little closer to the cause of #267.~~

Ok, fixed that, now we're seeing #267.