### PR TITLE
Don't test Django's master on python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,9 @@ matrix:
     - python: "3.2"
       env: TOXENV="djangodev"
 
+    - python: "2.7"
+      env: TOXENV="djangodev"
+
     - python: "2.6"
       env: TOXENV="django17"
     - python: "2.6"


### PR DESCRIPTION
Django 2.0 will be dropping support for python 2, so there's no point in running the tests in that combination.