### PR TITLE
Django compatibility cleanups and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.5"
   - "3.6"
 env:
-  - TOXENV="django18"
   - TOXENV="django110"
   - TOXENV="django111"
   - TOXENV="djangodev"
@@ -15,8 +14,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-    - python: "3.6"
-      env: TOXENV="django18"
     - python: "3.6"
       env: TOXENV="django110"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,55 @@
+# https://travis-ci.org/django-polymorphic/django-polymorphic
 sudo: false
 language: python
-cache: pip
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
+
+python: "3.6"
+
 env:
-  - TOXENV="django110"
-  - TOXENV="django111"
-  - TOXENV="djangodev"
+  - TOXENV=py27-django110
+  - TOXENV=py27-django111
+  - TOXENV=py34-django110
+  - TOXENV=py34-django111
+  - TOXENV=py35-django110
+  - TOXENV=py35-django111
+  - TOXENV=py35-djangomaster
+  - TOXENV=py36-django111
+  - TOXENV=py36-djangomaster
 
 matrix:
   fast_finish: true
+  include:
+    - python: "3.5"
+      env: TOXENV=py35-django110
+    - python: "3.5"
+      env: TOXENV=py35-django111
+    - python: "3.5"
+      env: TOXENV=py35-djangomaster
   exclude:
     - python: "3.6"
-      env: TOXENV="django110"
-
-    - python: "3.4"
-      env: TOXENV="django110"
-    - python: "3.4"
-      env: TOXENV="django111"
-
-    - python: "2.7"
-      env: TOXENV="djangodev"
-
+      env: TOXENV=py35-django110
+    - python: "3.6"
+      env: TOXENV=py35-django111
+    - python: "3.6"
+      env: TOXENV=py35-djangomaster
   allow_failures:
-    - env: TOXENV="djangodev"
+    - env: TOXENV=py35-djangomaster
+    - env: TOXENV=py36-djangomaster
 
-before_install:
-- pip install codecov coverage==3.6 tox
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $TRAVIS_BUILD_DIR/.tox
+
+install:
+  - pip install --upgrade pip wheel setuptools
+  - pip install codecov coverage tox
 
 script:
   - tox
 
 after_success:
-- coverage xml -i
-- codecov
+  - coverage xml -i
+  - codecov
 
 branches:
   only:

--- a/polymorphic/__init__.py
+++ b/polymorphic/__init__.py
@@ -7,5 +7,7 @@ This code and affiliated files are (C) by Bert Constantin and individual contrib
 Please see LICENSE and AUTHORS for more information.
 """
 
-# See PEP 440 (https://www.python.org/dev/peps/pep-0440/)
-__version__ = "1.3"
+import pkg_resources
+
+
+__version__ = pkg_resources.require("django-polymorphic")[0].version

--- a/polymorphic/admin/childadmin.py
+++ b/polymorphic/admin/childadmin.py
@@ -4,7 +4,7 @@ The child admin displays the change/delete view of the subclass model.
 import inspect
 
 from django.contrib import admin
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 

--- a/polymorphic/admin/helpers.py
+++ b/polymorphic/admin/helpers.py
@@ -3,12 +3,7 @@ Rendering utils for admin forms;
 
 This makes sure that admin fieldsets/layout settings are exported to the template.
 """
-import json
-
 from django.contrib.admin.helpers import InlineAdminFormSet, InlineAdminForm, AdminField
-from django.utils.encoding import force_text
-from django.utils.text import capfirst
-from django.utils.translation import ugettext
 
 from polymorphic.formsets import BasePolymorphicModelFormSet
 
@@ -81,30 +76,6 @@ class PolymorphicInlineAdminFormSet(InlineAdminFormSet):
         fields = self.prepopulated_fields.copy()
         fields.update(child_inline.get_prepopulated_fields(self.request, self.obj))
         return fields
-
-    # The polymorphic template follows the same method like all other inlines do in Django 1.10.
-    # This method is added for compatibility with older Django versions.
-    def inline_formset_data(self):
-        """
-        A JavaScript data structure for the JavaScript code
-        """
-        verbose_name = self.opts.verbose_name
-        return json.dumps({
-            'name': '#%s' % self.formset.prefix,
-            'options': {
-                'prefix': self.formset.prefix,
-                'addText': ugettext('Add another %(verbose_name)s') % {
-                    'verbose_name': capfirst(verbose_name),
-                },
-                'childTypes': [
-                    {
-                        'type': model._meta.model_name,
-                        'name': force_text(model._meta.verbose_name)
-                    } for model in self.formset.child_forms.keys()
-                ],
-                'deleteText': ugettext('Remove'),
-            }
-        })
 
 
 class PolymorphicInlineSupportMixin(object):

--- a/polymorphic/admin/parentadmin.py
+++ b/polymorphic/admin/parentadmin.py
@@ -10,9 +10,9 @@ from django.contrib.admin.helpers import AdminErrorList, AdminForm
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-from django.core.urlresolvers import RegexURLResolver
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse
+from django.urls import RegexURLResolver
 from django.utils.encoding import force_text
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe

--- a/polymorphic/admin/parentadmin.py
+++ b/polymorphic/admin/parentadmin.py
@@ -75,38 +75,8 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
         if self._is_setup:
             return
 
-        # By not having this in __init__() there is less stress on import dependencies as well,
-        # considering an advanced use cases where a plugin system scans for the child models.
-        child_models = self.get_child_models()
-        # Check if get_child_models() returns an iterable of models (new format) or an iterable
-        # of (Model, Admin) (legacy format). When iterable is empty, assume the new format.
-        self._compat_mode = len(child_models) and isinstance(child_models[0], (list, tuple))
-        if not self._compat_mode:
-            self._child_models = child_models
-            self._child_admin_site = self.admin_site
-            self._is_setup = True
-            return
-
-        # Continue only if in compatibility mode
-        warnings.warn("Using tuples of (Model, ModelAdmin) in PolymorphicParentModelAdmin.child_models is "
-                      "deprecated; instead child_models should be iterable of child models eg. "
-                      "(Model1, Model2, ..) and child admins should be registered to default admin site",
-                      DeprecationWarning)
-        self._child_admin_site = self.admin_site.__class__(name=self.admin_site.name)
-        self._child_admin_site.get_app_list = lambda request: ()  # HACK: workaround for Django 1.9
-
-        for Model, Admin in child_models:
-            self.register_child(Model, Admin)
-        self._child_models = dict(child_models)
-
-        # This is needed to deal with the improved ForeignKeyRawIdWidget in Django 1.4 and perhaps other widgets too.
-        # The ForeignKeyRawIdWidget checks whether the referenced model is registered in the admin, otherwise it displays itself as a textfield.
-        # As simple solution, just make sure all parent admin models are also know in the child admin site.
-        # This should be done after all parent models are registered off course.
-        complete_registry = self.admin_site._registry.copy()
-        complete_registry.update(self._child_admin_site._registry)
-
-        self._child_admin_site._registry = complete_registry
+        self._child_models = self.get_child_models()
+        self._child_admin_site = self.admin_site
         self._is_setup = True
 
     def register_child(self, model, model_admin):
@@ -144,11 +114,7 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
         """
         self._lazy_setup()
         choices = []
-        for child_model_desc in self.get_child_models():
-            if self._compat_mode:
-                model = child_model_desc[0]
-            else:
-                model = child_model_desc
+        for model in self.get_child_models():
             perm_function_name = 'has_{0}_permission'.format(action)
             model_admin = self._get_real_admin_by_model(model)
             perm_function = getattr(model_admin, perm_function_name)
@@ -265,28 +231,7 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
         # At this point. all admin code needs to be known.
         self._lazy_setup()
 
-        # Continue only if in compatibility mode
-        if not self._compat_mode:
-            return urls
-
-        # The redirect at the end acts as catch all.
-        # The custom urls need to be inserted before that.
-        redirect_urls = [pat for pat in urls if not pat.name]  # redirect URL has no name.
-        urls = [pat for pat in urls if pat.name]
-
-        # Define the catch-all for custom views
-        custom_urls = [
-            url(r'^(?P<path>.+)$', self.admin_site.admin_view(self.subclass_view))
-        ]
-
-        # Add reverse names for all polymorphic models, so the delete button and "save and add" just work.
-        # These definitions are masked by the definition above, since it needs special handling (and a ct_id parameter).
-        dummy_urls = []
-        for model, _ in self.get_child_models():
-            admin = self._get_real_admin_by_model(model)
-            dummy_urls += admin.get_urls()
-
-        return urls + custom_urls + dummy_urls + redirect_urls
+        return urls
 
     def subclass_view(self, request, path):
         """

--- a/polymorphic/base.py
+++ b/polymorphic/base.py
@@ -4,11 +4,10 @@ PolymorphicModel Meta Class
 """
 from __future__ import absolute_import
 
+import inspect
 import os
 import sys
-import inspect
 
-import django
 from django.db import models
 from django.db.models.base import ModelBase
 from django.db.models.manager import ManagerDescriptor
@@ -21,11 +20,6 @@ from .query import PolymorphicQuerySet
 POLYMORPHIC_SPECIAL_Q_KWORDS = ['instance_of', 'not_instance_of']
 
 DUMPDATA_COMMAND = os.path.join('django', 'core', 'management', 'commands', 'dumpdata.py')
-
-try:
-    from django.db.models.manager import AbstractManagerDescriptor  # Django 1.5
-except ImportError:
-    AbstractManagerDescriptor = None
 
 
 ###################################################################################
@@ -60,11 +54,6 @@ class PolymorphicModelBase(ModelBase):
 
         # Workaround compatibility issue with six.with_metaclass() and custom Django model metaclasses:
         if not attrs and model_name == 'NewBase':
-            if django.VERSION < (1, 5):
-                # Let Django fully ignore the class which is inserted in between.
-                # Django 1.5 fixed this, see https://code.djangoproject.com/ticket/19688
-                attrs['__module__'] = 'django.utils.six'
-                attrs['Meta'] = type('Meta', (), {'abstract': True})
             return super(PolymorphicModelBase, self).__new__(self, model_name, bases, attrs)
 
         # create new model
@@ -73,33 +62,9 @@ class PolymorphicModelBase(ModelBase):
         # check if the model fields are all allowed
         self.validate_model_fields(new_class)
 
-        # create list of all managers to be inherited from the base classes
-        if django.VERSION < (1, 10):
-            inherited_managers = new_class.get_inherited_managers(attrs)
-
-            # add the managers to the new model
-            for source_name, mgr_name, manager in inherited_managers:
-                # print '** add inherited manager from model %s, manager %s, %s' % (source_name, mgr_name, manager.__class__.__name__)
-                new_manager = manager._copy_to_model(new_class)
-                if mgr_name == '_default_manager':
-                    new_class._default_manager = new_manager
-                else:
-                    new_class.add_to_class(mgr_name, new_manager)
-
-            # get first user defined manager; if there is one, make it the _default_manager
-            # this value is used by the related objects, restoring access to custom queryset methods on related objects.
-            user_manager = self.get_first_user_defined_manager(new_class)
-            if user_manager:
-                # print '## add default manager', type(def_mgr)
-                new_class._default_manager = user_manager._copy_to_model(new_class)
-                new_class._default_manager._inherited = False   # the default mgr was defined by the user, not inherited
-
-        # validate resulting default manager (only on non-abstract and non-swapped models)
+        # validate resulting default manager
         if not new_class._meta.abstract and not new_class._meta.swapped:
-            if django.VERSION >= (1, 10):
-                self.validate_model_manager(new_class.objects, model_name, 'objects')
-            else:
-                self.validate_model_manager(new_class._default_manager, model_name, '_default_manager')
+            self.validate_model_manager(new_class.objects, model_name, "objects")
 
         # for __init__ function of this class (monkeypatching inheritance accessors)
         new_class.polymorphic_super_sub_accessors_replaced = False
@@ -112,73 +77,6 @@ class PolymorphicModelBase(ModelBase):
                 break
 
         return new_class
-
-    if django.VERSION < (1, 10):
-        def get_inherited_managers(self, attrs):
-            """
-            Return list of all managers to be inherited/propagated from the base classes;
-            use correct mro, only use managers with _inherited==False (they are of no use),
-            skip managers that are overwritten by the user with same-named class attributes (in attrs)
-            """
-            # print "** ", self.__name__
-            add_managers = []
-            add_managers_keys = set()
-            for base in self.__mro__[1:]:
-                if not issubclass(base, models.Model):
-                    continue
-                if not getattr(base, 'polymorphic_model_marker', None):
-                    continue  # leave managers of non-polym. models alone
-
-                for key, manager in base.__dict__.items():
-                    if type(manager) == models.manager.ManagerDescriptor:
-                        manager = manager.manager
-
-                    # As of Django 1.5, the abstract models don't get any managers, only a
-                    # AbstractManagerDescriptor as substitute.
-                    if type(manager) == AbstractManagerDescriptor and base.__name__ == 'PolymorphicModel':
-                        model = manager.model
-                        if key == 'objects':
-                            manager = PolymorphicManager()
-                            manager.model = model
-                        elif key == 'base_objects':
-                            manager = models.Manager()
-                            manager.model = model
-
-                    if AbstractManagerDescriptor is not None:
-                        # Django 1.4 unconditionally assigned managers to a model. As of Django 1.5 however,
-                        # the abstract models don't get any managers, only a AbstractManagerDescriptor as substitute.
-                        # Pretend that the manager is still there, so all code works like it used to.
-                        if type(manager) == AbstractManagerDescriptor and base.__name__ == 'PolymorphicModel':
-                            model = manager.model
-                            if key == 'objects':
-                                manager = PolymorphicManager()
-                                manager.model = model
-                            elif key == 'base_objects':
-                                manager = models.Manager()
-                                manager.model = model
-
-                    if not isinstance(manager, models.Manager):
-                        continue
-                    if key == '_base_manager':
-                        continue       # let Django handle _base_manager
-                    if key in attrs:
-                        continue
-                    if key in add_managers_keys:
-                        continue       # manager with that name already added, skip
-                    if manager._inherited:
-                        continue             # inherited managers (on the bases) have no significance, they are just copies
-                    # print '## {0} {1}'.format(self.__name__, key)
-
-                    if isinstance(manager, PolymorphicManager):  # validate any inherited polymorphic managers
-                        self.validate_model_manager(manager, self.__name__, key)
-                    add_managers.append((base.__name__, key, manager))
-                    add_managers_keys.add(key)
-
-            # The ordering in the base.__dict__ may randomly change depending on which method is added.
-            # Make sure base_objects is on top, and 'objects' and '_default_manager' follow afterwards.
-            # This makes sure that the _base_manager is also assigned properly.
-            add_managers = sorted(add_managers, key=lambda item: (item[1].startswith('_'), item[1]))
-            return add_managers
 
         @classmethod
         def get_first_user_defined_manager(mcs, new_class):

--- a/polymorphic/formsets/generic.py
+++ b/polymorphic/formsets/generic.py
@@ -1,4 +1,3 @@
-import django
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet, generic_inlineformset_factory
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -32,12 +31,8 @@ class GenericPolymorphicFormSetChild(PolymorphicFormSetChild):
         opts = self.model._meta
         ct_field = opts.get_field(self.ct_field)
 
-        if django.VERSION >= (1, 9):
-            if not isinstance(ct_field, models.ForeignKey) or ct_field.remote_field.model != ContentType:
-                raise Exception("fk_name '%s' is not a ForeignKey to ContentType" % ct_field)
-        else:
-            if not isinstance(ct_field, models.ForeignKey) or ct_field.rel.to != ContentType:
-                raise Exception("fk_name '%s' is not a ForeignKey to ContentType" % ct_field)
+        if not isinstance(ct_field, models.ForeignKey) or ct_field.remote_field.model != ContentType:
+            raise Exception("fk_name '%s' is not a ForeignKey to ContentType" % ct_field)
 
         fk_field = opts.get_field(self.fk_field)  # let the exception propagate
         exclude.extend([ct_field.name, fk_field.name])

--- a/polymorphic/formsets/models.py
+++ b/polymorphic/formsets/models.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-import django
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured, ValidationError
@@ -226,10 +225,7 @@ class BasePolymorphicModelFormSet(BaseModelFormSet):
         """
         forms = []
         for model, form_class in self.child_forms.items():
-            if django.VERSION >= (1, 9):
-                kwargs = self.get_form_kwargs(None)  # New Django 1.9 method
-            else:
-                kwargs = {}
+            kwargs = self.get_form_kwargs(None)
 
             form = form_class(
                 auto_id=self.auto_id,

--- a/polymorphic/manager.py
+++ b/polymorphic/manager.py
@@ -1,2 +1,0 @@
-# For compatibility with pre 0.8 versions
-from .managers import PolymorphicQuerySet, PolymorphicManager  # noqa

--- a/polymorphic/managers.py
+++ b/polymorphic/managers.py
@@ -3,7 +3,7 @@
 The manager class for use in the models.
 """
 from __future__ import unicode_literals
-import warnings
+
 from django.db import models
 from django.utils.six import python_2_unicode_compatible
 from polymorphic.query import PolymorphicQuerySet
@@ -32,17 +32,6 @@ class PolymorphicManager(models.Manager):
         manager = super(PolymorphicManager, cls).from_queryset(queryset_class, class_name=class_name)
         manager.queryset_class = queryset_class  # also set our version, Django uses _queryset_class
         return manager
-
-    def __init__(self, queryset_class=None, *args, **kwrags):
-        # Up till polymorphic 0.4, the queryset class could be specified as parameter to __init__.
-        # However, this doesn't work for related managers which instantiate a new version of this class.
-        # Hence, for custom managers the new default is using the 'queryset_class' attribute at class level instead.
-        if queryset_class:
-            warnings.warn("Using PolymorphicManager(queryset_class=..) is deprecated; override the queryset_class attribute instead", DeprecationWarning)
-            # For backwards compatibility, still allow the parameter:
-            self.queryset_class = queryset_class
-
-        super(PolymorphicManager, self).__init__(*args, **kwrags)
 
     def get_queryset(self):
         qs = self.queryset_class(self.model, using=self._db, hints=self._hints)

--- a/polymorphic/managers.py
+++ b/polymorphic/managers.py
@@ -23,8 +23,6 @@ class PolymorphicManager(models.Manager):
     Usually not explicitly needed, except if a custom manager or
     a custom queryset class is to be used.
     """
-    # Tell Django that related fields also need to use this manager:
-    use_for_related_fields = True
     queryset_class = PolymorphicQuerySet
 
     @classmethod

--- a/polymorphic/models.py
+++ b/polymorphic/models.py
@@ -40,9 +40,6 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
     # for PolymorphicQuery, True => an overloaded __repr__ with nicer multi-line output is used by PolymorphicQuery
     polymorphic_query_multiline_output = False
 
-    class Meta:
-        abstract = True
-
     # avoid ContentType related field accessor clash (an error emitted by model validation)
     #: The model field that stores the :class:`~django.contrib.contenttypes.models.ContentType` reference to the actual class.
     polymorphic_ctype = models.ForeignKey(
@@ -57,6 +54,10 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
     # They are pretended to be there by the metaclass in PolymorphicModelBase.get_inherited_managers()
     objects = PolymorphicManager()
     base_objects = models.Manager()
+
+    class Meta:
+        abstract = True
+        base_manager_name = "objects"
 
     @classmethod
     def translate_polymorphic_Q_object(cls, q):

--- a/polymorphic/models.py
+++ b/polymorphic/models.py
@@ -218,7 +218,7 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
                 if super_cls in sub_cls._meta.parents:  # super_cls may not be in sub_cls._meta.parents if super_cls is a proxy model
                     field_to_super = sub_cls._meta.parents[super_cls]  # get the field that links sub_cls to super_cls
                     if field_to_super is not None:    # if filed_to_super is not a link to a proxy model
-                        super_to_sub_related_field = field_to_super.rel
+                        super_to_sub_related_field = field_to_super.remote_field
                         if super_to_sub_related_field.related_name is None:
                             # if related name is None the related field is the name of the subclass
                             to_subclass_fieldname = sub_cls.__name__.lower()

--- a/polymorphic/query_translate.py
+++ b/polymorphic/query_translate.py
@@ -5,8 +5,8 @@ PolymorphicQuerySet support functions
 from __future__ import absolute_import
 
 import copy
-import django
 from functools import reduce
+
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.fields.related import ForeignObjectRel, RelatedField
@@ -86,13 +86,7 @@ def translate_polymorphic_filter_definitions_in_args(queryset_model, args, using
 
     Returns: modified Q objects
     """
-    if django.VERSION >= (1, 10):
-        q_objects = [copy.deepcopy(q) for q in args]
-    elif django.VERSION >= (1, 8):
-        q_objects = [q.clone() for q in args]
-    else:
-        q_objects = args  # NOTE: edits existing objects in place.
-    return [translate_polymorphic_Q_object(queryset_model, q, using=using) for q in q_objects]
+    return [translate_polymorphic_Q_object(queryset_model, copy.deepcopy(q), using=using) for q in args]
 
 
 def _translate_polymorphic_filter_definition(queryset_model, field_path, field_val, using=DEFAULT_DB_ALIAS):

--- a/polymorphic/showfields.py
+++ b/polymorphic/showfields.py
@@ -169,9 +169,3 @@ class ShowFieldTypeAndContent(ShowFieldBase):
     """ model mixin, like ShowFieldContent, but also show field types """
     polymorphic_showfield_type = True
     polymorphic_showfield_content = True
-
-
-# compatibility with old class names
-ShowFieldTypes = ShowFieldType
-ShowFields = ShowFieldContent
-ShowFieldsAndTypes = ShowFieldTypeAndContent

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -260,20 +260,11 @@ class PolymorphicTests(TestCase):
         self.assertEqual(show_base_manager(PlainC), "<class 'django.db.models.manager.Manager'> <class 'polymorphic.tests.PlainC'>")
 
         self.assertEqual(show_base_manager(Model2A), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.Model2A'>")
-        if django.VERSION >= (1, 10):
-            # The new inheritance makes all model levels polymorphic
-            self.assertEqual(show_base_manager(Model2B), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.Model2B'>")
-            self.assertEqual(show_base_manager(Model2C), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.Model2C'>")
-        else:
-            self.assertEqual(show_base_manager(Model2B), "<class 'django.db.models.manager.Manager'> <class 'polymorphic.tests.Model2B'>")
-            self.assertEqual(show_base_manager(Model2C), "<class 'django.db.models.manager.Manager'> <class 'polymorphic.tests.Model2C'>")
+        self.assertEqual(show_base_manager(Model2B), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.Model2B'>")
+        self.assertEqual(show_base_manager(Model2C), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.Model2C'>")
 
         self.assertEqual(show_base_manager(One2OneRelatingModel), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.One2OneRelatingModel'>")
-        if django.VERSION >= (1, 10):
-            # The new inheritance makes all model levels polymorphic
-            self.assertEqual(show_base_manager(One2OneRelatingModelDerived), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.One2OneRelatingModelDerived'>")
-        else:
-            self.assertEqual(show_base_manager(One2OneRelatingModelDerived), "<class 'django.db.models.manager.Manager'> <class 'polymorphic.tests.One2OneRelatingModelDerived'>")
+        self.assertEqual(show_base_manager(One2OneRelatingModelDerived), "<class 'polymorphic.managers.PolymorphicManager'> <class 'polymorphic.tests.One2OneRelatingModelDerived'>")
 
     def test_instance_default_manager(self):
         def show_default_manager(instance):
@@ -566,17 +557,6 @@ class PolymorphicTests(TestCase):
         # by choice of MRO, should be MyManager from MROBase1.
         self.assertIs(type(MRODerived.objects), MyManager)
 
-        if django.VERSION < (1, 10, 1):
-            # The change for https://code.djangoproject.com/ticket/27073
-            # in https://github.com/django/django/commit/d4eefc7e2af0d93283ed1c03e0af0a482982b6f0
-            # removes the assignment to _default_manager
-
-            # check for correct default manager
-            self.assertIs(type(MROBase1._default_manager), MyManager)
-
-            # Django vanilla inheritance does not inherit MyManager as _default_manager here
-            self.assertIs(type(MROBase2._default_manager), MyManager)
-
     def test_queryset_assignment(self):
         # This is just a consistency check for now, testing standard Django behavior.
         parent = PlainParentModelWithManager.objects.create()
@@ -783,13 +763,10 @@ def qrepr(data):
     Ensure consistent repr() output for the QuerySet object.
     """
     if isinstance(data, QuerySet):
-        if django.VERSION >= (1, 11):
-            return repr(data)
-        elif django.VERSION >= (1, 10):
-            # Django 1.11 still shows "<QuerySet [", not taking the actual type into account.
+        if django.VERSION < (1, 11):
+            # Django 1.10 still shows "<QuerySet [", not taking the actual type into account.
             return '<{0} {1}'.format(data.__class__.__name__, repr(data)[10:])
         else:
-            # Simulate Django 1.11 behavior for older Django versions.
-            return '<{0} {1}>'.format(data.__class__.__name__, repr(data))
+            return repr(data)
 
     return repr(data)

--- a/polymorphic/tests/test_utils.py
+++ b/polymorphic/tests/test_utils.py
@@ -28,9 +28,13 @@ class UtilsTests(TestCase):
             list(Model2A.objects.all())
 
         reset_polymorphic_ctype(Model2D, Model2B, Model2D, Model2A, Model2C)
-        self.assertEqual(qrepr(Model2A.objects.order_by('pk')), (
-            '[ <Model2A: id 1, field1 (CharField)>,\n'
-            '  <Model2D: id 2, field1 (CharField), field2 (CharField), field3 (CharField), field4 (CharField)>,\n'
-            '  <Model2B: id 3, field1 (CharField), field2 (CharField)>,\n'
-            '  <Model2B: id 4, field1 (CharField), field2 (CharField)> ]'
-        ))
+
+        field_reprs = [
+            "<Model2A: id 1, field1 (CharField)>",
+            "<Model2D: id 2, field1 (CharField), field2 (CharField), field3 (CharField), field4 (CharField)>",
+            "<Model2B: id 3, field1 (CharField), field2 (CharField)>",
+            "<Model2B: id 4, field1 (CharField), field2 (CharField)>",
+        ]
+
+        for f, f_repr in zip(Model2A.objects.order_by("pk"), field_reprs):
+            self.assertEqual(qrepr(f), f_repr)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,39 @@
-[wheel]
-# create "py2.py3-none-any.whl" package
-universal = 1
+[metadata]
+name = django-polymorphic
+version = 1.3
+description = Seamless polymorphic inheritance for Django models
+author = Bert Constantin
+author_email = bert.constantin@gmx.de
+maintainer = Christopher Glass
+maintainer_email = tribaal@gmail.com
+url = https://github.com/django-polymorphic/django-polymorphic
+download_url = https://github.com/django-polymorphic/django-polymorphic/tarball/master
+keywords = django, polymorphic
+classifiers =
+	Development Status :: 5 - Production/Stable
+	Environment :: Web Environment
+	Framework :: Django
+	Framework :: Django :: 1.10
+	Framework :: Django :: 1.11
+	Intended Audience :: Developers
+	License :: OSI Approved :: BSD License
+	Operating System :: OS Independent
+	Programming Language :: Python :: 2.7
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.4
+	Programming Language :: Python :: 3.5
+	Programming Language :: Python :: 3.6
+	Topic :: Database
 
-[flake8]
-# ignore line size
-max-line-length = 300
+[options]
+packages = find:
+include_package_data = True
+install_requires =
+	Django >= 1.10
+
+[options.packages.find]
+exclude =
+	polymorphic.tests
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Topic :: Software Development :: Libraries :: Python Modules',

--- a/setup.py
+++ b/setup.py
@@ -1,58 +1,6 @@
 #!/usr/bin/env python
-import codecs
-import re
-from os import path
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
-def read(*parts):
-    file_path = path.join(path.dirname(__file__), *parts)
-    return codecs.open(file_path, encoding='utf-8').read()
-
-
-def find_version(*parts):
-    version_file = read(*parts)
-    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
-    if version_match:
-        return str(version_match.group(1))
-    raise RuntimeError("Unable to find version string.")
-
-
-setup(
-    name='django-polymorphic',
-    version=find_version('polymorphic', '__init__.py'),
-    license='BSD',
-
-    description='Seamless Polymorphic Inheritance for Django Models',
-    long_description=read('README.rst'),
-    url='https://github.com/django-polymorphic/django-polymorphic',
-
-    author='Bert Constantin',
-    author_email='bert.constantin@gmx.de',
-
-    maintainer='Christopher Glass',
-    maintainer_email='tribaal@gmail.com',
-
-    packages=find_packages(),
-    include_package_data=True,
-
-    test_suite='runtests',
-
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Framework :: Django',
-        'Framework :: Django :: 1.10',
-        'Framework :: Django :: 1.11',
-        'Topic :: Software Development :: Libraries :: Python Modules',
-    ]
-)
+setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 envlist =
-    py27-django{110,111}
-    py34-django{110,111}
-    py35-django{110,111,dev}
-    py36-django{111,dev}
-    docs
+	py27-django{110,111}
+	py34-django{110,111}
+	py35-django{110,111,master}
+	py36-django{111,master}
+	docs
 
 [testenv]
 setenv =
 	PYTHONWARNINGS = all
 deps =
-    coverage == 3.6
-    django110: Django >= 1.10, < 1.11
-    django111: Django >= 1.11, < 1.12
-    djangodev: https://github.com/django/django/tarball/master
+	coverage
+	django110: Django >= 1.10, < 1.11
+	django111: Django >= 1.11, < 2.0
+	djangomaster: https://github.com/django/django/archive/master.tar.gz
 commands =
-    coverage run --source polymorphic runtests.py
+	coverage run --source polymorphic runtests.py
 
 [testenv:docs]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py27-django{18,110,111}
-    py34-django{18,110,111}
-    py35-django{18,110,111,dev}
+    py27-django{110,111}
+    py34-django{110,111}
+    py35-django{110,111,dev}
     py36-django{111,dev}
     docs
 
@@ -11,7 +11,6 @@ setenv =
 	PYTHONWARNINGS = all
 deps =
     coverage == 3.6
-    django18: Django >= 1.8, < 1.9
     django110: Django >= 1.10, < 1.11
     django111: Django >= 1.11, < 1.12
     djangodev: https://github.com/django/django/tarball/master

--- a/tox.ini
+++ b/tox.ini
@@ -25,3 +25,7 @@ deps =
 	django-extra-views
 changedir = docs
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+[flake8]
+# ignore line size
+max-line-length = 300


### PR DESCRIPTION
This PR does a few things. In the first two commits:

- We no longer test on versions of Django and Python which are no longer supported.
- Remove all pre-django 1.8 hacks.

Then, in a separate commit, we remove support for Django 1.8 as well. I kept this separate because I may understand the argument to keep Django 1.8 as it is still supported upstream... *however*, Django 1.11 is the new LTS and, given the complexity of django-polymorphic and the amount of hacks dropping 1.8 removes, I would *very highly* recommend dropping 1.8 support as well, and recommend django-polymorphic==1.2 to Django 1.8 users.

As a followup to this, I am also improving compatibility with Django 2.0, to the point that tests now pass on django-dev. I cannot vouch for their reliability, however, especially given that I still see the following warning on 1.11 with -Wall:

```
Using Django version 1.11.1 from /home/adys/tmp/django-polymorphic/.tox/py36-django111/lib/python3.6/site-packages/django
/home/adys/tmp/django-polymorphic/.tox/py36-django111/lib/python3.6/site-packages/django/db/models/base.py:363: RemovedInDjango20Warning: Managers from concrete parents will soon qualify as default managers if they appear before any other managers in the MRO. As a result, 'base_objects' declared on 'polymorphic.PolymorphicModel' will no longer be the default manager for 'polymorphic.MROBase2' in favor of 'objects' declared on 'polymorphic.MROBase1'. You can redeclare 'base_objects' on 'MROBase2' to keep things the way they are or you can switch to the new behavior right away by setting `Meta.manager_inheritance_from_future` to `True`.
  if not opts.managers or cls._requires_legacy_default_manager():
/home/adys/tmp/django-polymorphic/.tox/py36-django111/lib/python3.6/site-packages/django/db/models/base.py:363: RemovedInDjango20Warning: Managers from concrete parents will soon qualify as default managers. As a result, the 'objects' manager won't be created (or recreated) automatically anymore on 'polymorphic.MgrInheritC' and 'mgrB' declared on 'polymorphic.MgrInheritB' will be promoted to default manager. You can declare explicitly `objects = models.Manager()` on 'MgrInheritC' to keep things the way they are or you can switch to the new behavior right away by setting `Meta.manager_inheritance_from_future` to `True`.
  if not opts.managers or cls._requires_legacy_default_manager():
```

Closes #287