### PR TITLE
Fix accessor replacement consistency on Django 1.11

### DIFF
--- a/polymorphic/models.py
+++ b/polymorphic/models.py
@@ -173,9 +173,9 @@ class PolymorphicModel(six.with_metaclass(PolymorphicModelBase, models.Model)):
                 ReverseSingleRelatedObjectDescriptor as ForwardManyToOneDescriptor,
             )
         for name, model in subclasses_and_superclasses_accessors.items():
+            # Here be dragons.
             orig_accessor = getattr(self.__class__, name, None)
-            if type(orig_accessor) in [ReverseOneToOneDescriptor, ForwardManyToOneDescriptor]:
-                # print >>sys.stderr, '---------- replacing', name, orig_accessor, '->', model
+            if issubclass(type(orig_accessor), (ReverseOneToOneDescriptor, ForwardManyToOneDescriptor)):
                 setattr(self.__class__, name, property(create_accessor_function_for_model(model, name)))
 
     def _get_inheritance_relation_fields_and_models(self):


### PR DESCRIPTION
At this point, we don't know why this line of code is executed, but
we do know it's not consistently executed between Django 1.10 and
Django 1.11 due to the addition of `ForwardOneToOneDescriptor`, a
subclass of `ForwardManyToOneDescriptor`.

Refs. 6628145af7e894f6977e3a14a713ac14449f3a4e
Refs. dj-stripe/dj-stripe#524
Refs. django/django@38575b007a722d6af510ea46d46393a4cda9ca29