### PR TITLE
Fixed PO files which resulted in SyntaxError when parsed by polib

### DIFF
--- a/polymorphic/locale/en/LC_MESSAGES/django.po
+++ b/polymorphic/locale/en/LC_MESSAGES/django.po
@@ -26,10 +26,10 @@ msgid "Content type"
 msgstr ""
 
 # This is already translated in Django
-#: admin.py:333
-#, python-format
-#msgid "Add %s"
-#msgstr ""
+# #: admin.py:333
+# #, python-format
+# msgid "Add %s"
+# msgstr ""
 
 #: admin.py:403
 msgid "Contents"

--- a/polymorphic/locale/fr/LC_MESSAGES/django.po
+++ b/polymorphic/locale/fr/LC_MESSAGES/django.po
@@ -27,10 +27,10 @@ msgid "Content type"
 msgstr "Type de contenu"
 
 # This is already translated in Django
-#: admin.py:333
-#, python-format
-#msgid "Add %s"
-#msgstr ""
+# #: admin.py:333
+# #, python-format
+# msgid "Add %s"
+# msgstr ""
 
 #: admin.py:403
 msgid "Contents"


### PR DESCRIPTION
We're using django-rosetta which uses polib to parse PO files and it fails with django-polymorphic's en/fr PO files resulting in SyntaxError.

This applies to both `#msgid` and `#msgstr` entries and problem lies that comments in PO files should have space after `#` character, otherwise they're handled as unknown token, thus SyntaxError.

This PR fixes the problem.