### PR TITLE
Swapped polymorphic models don't work on Django>=1.10

### DIFF
--- a/polymorphic/base.py
+++ b/polymorphic/base.py
@@ -94,11 +94,12 @@ class PolymorphicModelBase(ModelBase):
                 new_class._default_manager = user_manager._copy_to_model(new_class)
                 new_class._default_manager._inherited = False   # the default mgr was defined by the user, not inherited
 
-        # validate resulting default manager
-        if django.VERSION >= (1, 10) and not new_class._meta.abstract:
-            self.validate_model_manager(new_class.objects, model_name, 'objects')
-        else:
-            self.validate_model_manager(new_class._default_manager, model_name, '_default_manager')
+        # validate resulting default manager (only on non-abstract and non-swapped models)
+        if not new_class._meta.abstract and not new_class._meta.swapped:
+            if django.VERSION >= (1, 10):
+                self.validate_model_manager(new_class.objects, model_name, 'objects')
+            else:
+                self.validate_model_manager(new_class._default_manager, model_name, '_default_manager')
 
         # for __init__ function of this class (monkeypatching inheritance accessors)
         new_class.polymorphic_super_sub_accessors_replaced = False

--- a/polymorphic/tests/__init__.py
+++ b/polymorphic/tests/__init__.py
@@ -400,6 +400,23 @@ class DateModel(PolymorphicModel):
     date = models.DateTimeField()
 
 
+# Define abstract and swappable (being swapped for SwappedModel) models
+# To test manager validation (should be skipped for such models)
+class AbstractModel(PolymorphicModel):
+    class Meta:
+        abstract = True
+
+
+class SwappableModel(AbstractModel):
+    class Meta:
+        swappable = 'POLYMORPHIC_TEST_SWAPPABLE'
+
+
+class SwappedModel(AbstractModel):
+    pass
+
+
+
 # Import tests
 from .test_admin import *
 from .test_orm import *

--- a/runtests.py
+++ b/runtests.py
@@ -57,7 +57,8 @@ if not settings.configured:
                     ),
                 },
             },
-        ]
+        ],
+        POLYMORPHIC_TEST_SWAPPABLE='polymorphic.swappedmodel',
     )
 
 


### PR DESCRIPTION
This is so because polymorphic tries to validate manager on a swapped model while such manager is inaccessible (described in detail in #270)