### PR TITLE
fix error with .defer and child models that use the same parent

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -8,6 +8,7 @@ import copy
 from collections import defaultdict
 
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import FieldDoesNotExist
 from django.db.models.query import ModelIterable, Q, QuerySet
 from django.utils import six
 
@@ -392,6 +393,10 @@ class PolymorphicQuerySet(QuerySet):
                         # now a superclass of real_concrete_class. Thus it's
                         # sufficient to just use the field name.
                         translated_field_name = field.rpartition('___')[-1]
+                        try:
+                            real_concrete_class._meta.get_field(translated_field_name)
+                        except FieldDoesNotExist:
+                            continue
                     else:
                         raise
 

--- a/polymorphic/tests/__init__.py
+++ b/polymorphic/tests/__init__.py
@@ -82,6 +82,7 @@ class ModelShow2_plain(ModelShow1_plain):
 
 class Base(ShowFieldType, PolymorphicModel):
     field_b = models.CharField(max_length=10)
+    polymorphic_showfield_deferred = True
 
 
 class ModelX(Base):

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -178,6 +178,23 @@ class PolymorphicTests(TestCase):
                          '<Model2D: id 4, field1 (CharField), field2 (CharField), field3 (CharField), field4 (CharField), '
                          'deferred[field2,field3,field4,model2a_ptr_id,model2b_ptr_id]>')
 
+        ModelX.objects.create(field_b="A1", field_x="A2")
+        ModelY.objects.create(field_b="B1", field_y="B2")
+
+        objects_deferred = Base.objects.defer('ModelY___field_y')
+        self.assertEqual(repr(objects_deferred[0]),
+                         '<ModelX: id 1, field_b (CharField), field_x (CharField)>')
+        self.assertEqual(repr(objects_deferred[1]),
+                         '<ModelY: id 2, field_b (CharField), field_y (CharField), deferred[field_y]>')
+
+        objects_only = Base.objects.only(
+            'polymorphic_ctype', 'ModelY___field_y', 'ModelX___field_x',
+        )
+        self.assertEqual(repr(objects_only[0]),
+                         '<ModelX: id 1, field_b (CharField), field_x (CharField), deferred[field_b]>')
+        self.assertEqual(repr(objects_only[1]),
+                         '<ModelY: id 2, field_b (CharField), field_y (CharField), deferred[field_b]>')
+
     def test_defer_related_fields(self):
         self.create_model2abcd()
 


### PR DESCRIPTION
When using .defer on a PolymorphicQuerySet with multiple childs that
subclass from the same polymorphic parent model yield an error like:

```
>>> Base.objects.defer('ModelY___field_y')
Traceback (most recent call last):
...
FieldDoesNotExist: ModelX has no field named 'field_y'
```