### PR TITLE
Simple fix for compatibility with other admin extensions

### DIFF
--- a/polymorphic/admin/helpers.py
+++ b/polymorphic/admin/helpers.py
@@ -91,7 +91,7 @@ class PolymorphicInlineSupportMixin(object):
     :class:`~django.contrib.admin.helpers.InlineAdminFormSet` for the polymorphic formsets.
     """
 
-    def get_inline_formsets(self, request, formsets, inline_instances, obj=None):
+    def get_inline_formsets(self, request, formsets, inline_instances, obj=None, *args, **kwargs):
         """
         Overwritten version to produce the proper admin wrapping for the
         polymorphic inline formset. This fixes the media and form appearance


### PR DESCRIPTION
Allowing variable-length arguments in `get_inline_formsets` of `PolymorphicInlineSupportMixin` to fix compatibility with other admin extensions.

For example, when used alongside [django nested admin](https://github.com/theatlantic/django-nested-admin), we see the following error:

`get_inline_formsets() got an unexpected keyword argument 'allow_nested'`

This change simply ignores any extra arguments passed in by these other mixins.