### PR TITLE
Do not use deprecated and removed declared_fieldsets attribute in admin

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,10 +18,10 @@ Changes in git
 * Added ``PolymorphicTypeInvalid`` exception when database was incorrectly imported.
 * Added ``polymorphic.utils.get_base_polymorphic_model()`` to find the base model for types.
 * Using ``base_model`` on the polymorphic admins is no longer required, as this can be autodetected.
-* Fixed detection and handling of ``declared_fieldsets`` in the admin.
 * Fixed manager errors for swappable models.
 * Fixed deleteText of ``|as_script_options`` template filter.
 * Improved ``polymorphic.utils.reset_polymorphic_ctype()`` to accept models in random ordering.
+* Fix fieldsets handling in the admin (``declared_fieldsets`` is removed since Django 1.9)
 
 
 Version 1.3 (2017-08-01)

--- a/polymorphic/admin/childadmin.py
+++ b/polymorphic/admin/childadmin.py
@@ -62,10 +62,6 @@ class PolymorphicChildModelAdmin(admin.ModelAdmin):
         # If the derived class sets the model explicitly, respect that setting.
         kwargs.setdefault('form', self.base_form or self.form)
 
-        # prevent infinite recursion in django 1.6+
-        if not getattr(self, 'declared_fieldsets', None):
-            kwargs.setdefault('fields', None)
-
         return super(PolymorphicChildModelAdmin, self).get_form(request, obj, **kwargs)
 
     def get_model_perms(self, request):
@@ -186,9 +182,8 @@ class PolymorphicChildModelAdmin(admin.ModelAdmin):
     # ---- Extra: improving the form/fieldset default display ----
 
     def get_fieldsets(self, request, obj=None):
-        # If subclass declares fieldsets, this is respected
-        if (hasattr(self, 'declared_fieldsets') and self.declared_fieldsets) \
-           or not self.base_fieldsets:
+        # If subclass declares fieldsets or fields, this is respected
+        if hasattr(self, 'fieldsets') or hasattr(self, 'fields') or not self.base_fieldsets:
             return super(PolymorphicChildModelAdmin, self).get_fieldsets(request, obj)
 
         # Have a reasonable default fieldsets,


### PR DESCRIPTION
`ModelAdmin.declared_fieldsets` property was removed in Django 1.9. Checking `fieldsets` and `fields` is equivalent and will actually make that `if` do it's work.