### PR TITLE
update MIDDLEWARE variable

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -41,7 +41,7 @@ STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/runtests.py
+++ b/runtests.py
@@ -38,7 +38,7 @@ if not settings.configured:
             'polymorphic',
             'polymorphic.tests',
         ),
-        MIDDLEWARE_CLASSES=(),
+        MIDDLEWARE=(),
         SITE_ID=3,
         TEMPLATES=[{
                 "BACKEND": "django.template.backends.django.DjangoTemplates",


### PR DESCRIPTION
This is compatible with Django 1.10+, and required for Django 2.0

> You’ll need to adapt old, custom middleware and switch from the MIDDLEWARE_CLASSES setting to the new MIDDLEWARE setting to take advantage of the improvements.

source: https://docs.djangoproject.com/en/1.11/releases/1.10/

related #325 #324