### PR TITLE
update tests + CI against django 2.0, fix #325

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,17 @@ env:
   - TOXENV=py27-django111
   - TOXENV=py34-django110
   - TOXENV=py34-django111
+  - TOXENV=py34-django20
   - TOXENV=py35-django110
   - TOXENV=py35-django111
+  - TOXENV=py35-django20
   - TOXENV=py35-djangomaster
   - TOXENV=py36-django111
+  - TOXENV=py36-django20
   - TOXENV=py36-djangomaster
   # XXX: Use a matrix to build these?
   - TOXENV=py36-django111-postgres DB=postgres
+  - TOXENV=py36-django20-postgres DB=postgres
   - TOXENV=py36-djangomaster-postgres DB=postgres
 
 services:
@@ -29,12 +33,16 @@ matrix:
     - python: "3.5"
       env: TOXENV=py35-django111
     - python: "3.5"
+      env: TOXENV=py35-django20
+    - python: "3.5"
       env: TOXENV=py35-djangomaster
   exclude:
     - python: "3.6"
       env: TOXENV=py35-django110
     - python: "3.6"
       env: TOXENV=py35-django111
+    - python: "3.6"
+      env: TOXENV=py35-django20
     - python: "3.6"
       env: TOXENV=py35-djangomaster
   allow_failures:

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist =
 	py27-django{110,111}
-	py34-django{110,111}
-	py35-django{110,111,master}
-	py36-django{111,master}
+	py34-django{110,111,20}
+	py35-django{110,111,20,master}
+	py36-django{111,20,master}
 	docs
 
 [testenv]
@@ -16,6 +16,7 @@ deps =
 	dj-database-url
 	django110: Django >= 1.10, < 1.11
 	django111: Django >= 1.11, < 2.0
+	django20: Django >= 2.0, < 2.1
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
 	postgres: psycopg2
 commands =


### PR DESCRIPTION
This sets a baseline that further contributions work against django
2.0.