### PR TITLE
Fix prefetch_related behavior

### DIFF
--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -73,6 +73,7 @@ from polymorphic.tests.models import (
     RelationB,
     RelationBC,
     RelationBase,
+    RelatingModel,
     RubberDuck,
     TestParentLinkAndRelatedName,
     UUIDArtProject,
@@ -997,3 +998,12 @@ class PolymorphicTests(TransactionTestCase):
             MultiTableDerived.objects.bulk_create([
                 MultiTableDerived(field1='field1', field2='field2')
             ])
+
+    def test_prefetch_related_behaves_normally_with_polymorphic_model(self):
+        b1 = RelatingModel.objects.create()
+        b2 = RelatingModel.objects.create()
+        a = b1.many2many.create()
+        b2.many2many.add(a)
+        qs = RelatingModel.objects.prefetch_related('many2many')
+        for obj in qs:
+            self.assertEqual(len(obj.many2many.all()), 1)


### PR DESCRIPTION
I stumbled upon https://github.com/django-polymorphic/django-polymorphic/issues/68 which causes some errors for us. As mentioned in the issue, the problem is cause by reusing the instances stored in base_result_objects_by_id. This PR tries to work around it by maintaining the lists differently which allows to make shallow copies of the real instances (see line 417). Feel free to test!