### PR TITLE
replace iterable class in qs.non_polymorphic

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -138,6 +138,8 @@ class PolymorphicQuerySet(QuerySet):
         base class used for this query are returned."""
         qs = self._clone()
         qs.polymorphic_disabled = True
+        if issubclass(qs._iterable_class, PolymorphicModelIterable):
+            qs._iterable_class = ModelIterable
         return qs
 
     def instance_of(self, *args):


### PR DESCRIPTION
Long story short:
* We use django-polymorphic with django-cacheops
* Considering models: `Content` - parent and `Movie` - child
* Content has boolean `published` field

1. Fetching `Content.objects.get(pk=pk)` caches Movie object as content.
2. Fetching `Content.objects.non_polymorphic().get(pk=pk)` receives Movie object from cache, while expecting Content object only.
3. Changing `movie.published` invalidates with value for all Movie cache entries, but not Content one because of unexpected model class.

The solution is to cache polymorphic and non-polymorphic versions separately. This can be done with replacing `qs._iterable_class` to default Django's (cacheops respects `_iterable_class` when computes cache key).