### PR TITLE
Support Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,6 @@ sudo: false
 language: python
 dist: xenial
 
-python: "3.6"
-
-env:
-  - TOXENV=py27-django111
-  - TOXENV=py34-django111
-  - TOXENV=py34-django20
-  - TOXENV=py35-django111
-  - TOXENV=py35-django20
-  - TOXENV=py35-djangomaster
-  - TOXENV=py36-django111
-  - TOXENV=py36-django20
-  - TOXENV=py36-django21
-  - TOXENV=py36-django22
-  - TOXENV=py36-djangomaster
-  # XXX: Use a matrix to build these?
-  - TOXENV=py36-django111-postgres DB=postgres
-  - TOXENV=py36-django20-postgres DB=postgres
-  - TOXENV=py36-djangomaster-postgres DB=postgres
-
 services:
   - postgres
 addons:
@@ -30,27 +11,36 @@ addons:
 matrix:
   fast_finish: true
   include:
-    - python: "2.7"
-      env: TOXENV=py27-django111
-    - python: "3.5"
-      env: TOXENV=py35-django111
-    - python: "3.5"
-      env: TOXENV=py35-django20
-    - python: "3.5"
-      env: TOXENV=py35-djangomaster
-  exclude:
-    - python: "3.6"
-      env: TOXENV=py27-django111
-    - python: "3.6"
-      env: TOXENV=py35-django111
-    - python: "3.6"
-      env: TOXENV=py35-django20
-    - python: "3.6"
-      env: TOXENV=py35-djangomaster
+    # Django 1.11: Python 2.7, 3.4, 3.5, or 3.6
+    - { env: TOXENV=py27-django111, python: 2.7 }
+    - { env: TOXENV=py34-django111, python: 3.4 }
+    - { env: TOXENV=py35-django111, python: 3.5 }
+    - { env: TOXENV=py36-django111, python: 3.6 }
+    - { env: TOXENV=py36-django111-postgres DB=postgres, python: 3.6 }
+    # Django 2.0: Python 3.4, 3.5, or 3.6
+    - { env: TOXENV=py34-django20, python: 3.4 }
+    - { env: TOXENV=py35-django20, python: 3.5 }
+    - { env: TOXENV=py36-django20, python: 3.6 }
+    - { env: TOXENV=py36-django20-postgres DB=postgres, python: 3.6 }
+    # Django 2.1: Python 3.6, or 3.7
+    - { env: TOXENV=py36-django21, python: 3.6 }
+    - { env: TOXENV=py37-django21, python: 3.7 }
+    - { env: TOXENV=py37-django21-postgres DB=postgres, python: 3.7 }
+    # Django 2.2: Python 3.6, or 3.7
+    - { env: TOXENV=py36-django22, python: 3.6 }
+    - { env: TOXENV=py37-django22, python: 3.7 }
+    - { env: TOXENV=py37-django22-postgres DB=postgres, python: 3.7 }
+    # Django development master (direct from GitHub source):
+    - { env: TOXENV=py35-djangomaster, python: 3.5 }
+    - { env: TOXENV=py36-djangomaster, python: 3.6 }
+    - { env: TOXENV=py37-djangomaster, python: 3.7 }
+    - { env: TOXENV=py37-djangomaster-postgres DB=postgres, python: 3.7 }
+
   allow_failures:
-    - env: TOXENV=py35-djangomaster
-    - env: TOXENV=py36-djangomaster
-    - env: TOXENV=py36-djangomaster-postgres DB=postgres
+    - { env: TOXENV=py35-djangomaster, python: 3.5 }
+    - { env: TOXENV=py36-djangomaster, python: 3.6 }
+    - { env: TOXENV=py37-djangomaster, python: 3.7 }
+    - { env: TOXENV=py37-djangomaster-postgres DB=postgres, python: 3.7 }
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # https://travis-ci.org/django-polymorphic/django-polymorphic
 sudo: false
 language: python
+dist: xenial
 
 python: "3.6"
 
@@ -14,6 +15,7 @@ env:
   - TOXENV=py36-django111
   - TOXENV=py36-django20
   - TOXENV=py36-django21
+  - TOXENV=py36-django22
   - TOXENV=py36-djangomaster
   # XXX: Use a matrix to build these?
   - TOXENV=py36-django111-postgres DB=postgres

--- a/polymorphic/formsets/utils.py
+++ b/polymorphic/formsets/utils.py
@@ -10,7 +10,10 @@ def add_media(dest, media):
 
     Only required for Django < 2.0
     """
-    if django.VERSION >= (2, 0):
+    if django.VERSION >= (2, 2):
+        dest._css_lists.extend(media._css_lists)
+        dest._js_lists.extend(media._js_lists)
+    elif django.VERSION >= (2, 0):
         combined = dest + media
         dest._css = combined._css
         dest._js = combined._js

--- a/runtests.py
+++ b/runtests.py
@@ -37,12 +37,17 @@ if not settings.configured:
             'django.contrib.auth',
             'django.contrib.contenttypes',
             'django.contrib.messages',
+            'django.contrib.sessions',
             'django.contrib.sites',
             'django.contrib.admin',
             'polymorphic',
             'polymorphic.tests',
         ),
-        MIDDLEWARE_CLASSES=(),
+        MIDDLEWARE=(
+            'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'django.contrib.messages.middleware.MessageMiddleware',
+            'django.contrib.sessions.middleware.SessionMiddleware',
+        ),
         SITE_ID=3,
         TEMPLATES=[{
             "BACKEND": "django.template.backends.django.DjangoTemplates",

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ classifiers =
 	Framework :: Django
 	Framework :: Django :: 1.11
 	Framework :: Django :: 2.0
+	Framework :: Django :: 2.1
+	Framework :: Django :: 2.2
 	Intended Audience :: Developers
 	License :: OSI Approved :: BSD License
 	Operating System :: OS Independent
@@ -24,6 +26,7 @@ classifiers =
 	Programming Language :: Python :: 3.4
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
+        Programming Language :: Python :: 3.7
 	Topic :: Database
 
 [options]

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
 	py27-django{111}
 	py34-django{111,20}
 	py35-django{111,20,master}
-	py36-django{111,20,21,master}
-	py37-django{21,master}
+	py36-django{111,20,21,22,master}
+	py37-django{21,22,master}
 	docs
 
 [testenv]
@@ -18,6 +18,7 @@ deps =
 	django111: Django >= 1.11, < 2.0
 	django20: Django ~= 2.0
 	django21: Django ~= 2.1
+	django22: Django ~= 2.2
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
 	postgres: psycopg2
 commands =


### PR DESCRIPTION
Following up on work started in https://github.com/django-polymorphic/django-polymorphic/pull/379 by @auvipy.

- add fix to `formsets.utils.add_media` to support Django 2.2
- add Django 2.2 to test matrix
- add missing middlewares to get tests working on Django 2+

The master branch tests are failing because Django has started removing support for python2, so `django.utils.six` is no longer available.