### PR TITLE
One-level select_related

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -410,7 +410,21 @@ class PolymorphicQuerySet(QuerySet):
                 **{("%s__in" % pk_name): idlist}
             )
             # copy select related configuration to new qs
-            real_objects.query.select_related = self.query.select_related
+
+            if self.query.select_related is False:
+                real_objects.query.select_related = False
+            else:
+                concrete_model_name = real_concrete_class._meta.model_name
+                sub_model_names = set([m._meta.model_name for m in self.model.__subclasses__()])
+                sub_model_names.remove(concrete_model_name)
+
+                for sub_name in sub_model_names:
+                    self.query.select_related.pop(sub_name, None)
+
+                if concrete_model_name in self.query.select_related:
+                    real_objects.query.select_related = self.query.select_related[concrete_model_name]
+                else:
+                    real_objects.query.select_related = self.query.select_related
 
             # Copy deferred fields configuration to the new queryset
             deferred_loading_fields = []


### PR DESCRIPTION
This is an attempt at adding support for `select_related` and thus closing #198. So far it has no unit tests or documentation and has mostly been tested with [Graphene-Django](https://github.com/graphql-python/graphene-django) which is where I found my need for this. 

(Getting [graphene-django-optimizer](https://github.com/tfoxy/graphene-django-optimizer) to work with this is the next step!)

With my limited testing it seems to work at the first level (e.g. `Parent.objects.select_related('childa__related')`) but not any deeper than that (e.g. `Parent.objects.select_related('childa__related__childb')`)

This PR is not in a mergeable state and instead is currently mostly created for bringing the discussion further for implementing `select_related` with a more complete solution.