### PR TITLE
Q object child is a list or tuple

### DIFF
--- a/polymorphic/query_translate.py
+++ b/polymorphic/query_translate.py
@@ -68,7 +68,7 @@ def translate_polymorphic_Q_object(
         for i in range(len(node.children)):
             child = node.children[i]
 
-            if type(child) == tuple:
+            if type(child) == tuple or type(child) == list:
                 # this Q object child is a tuple => a kwarg like Q( instance_of=ModelB )
                 key, val = child
                 new_expr = _translate_polymorphic_filter_definition(


### PR DESCRIPTION
With installed `django-advanced-filters` app, filter polymorphic model return `Q` object child list, not tuple.