### PR TITLE
Non polymorphic parent

### DIFF
--- a/polymorphic/models.py
+++ b/polymorphic/models.py
@@ -205,7 +205,8 @@ class PolymorphicModel(with_metaclass(PolymorphicModelBase, models.Model)):
 
         def create_accessor_function_for_model(model, accessor_name):
             def accessor_function(self):
-                attr = model._base_objects.get(pk=self.pk)
+                objects = getattr(model, "_base_objects", model.objects)
+                attr = objects.get(pk=self.pk)
                 return attr
 
             return accessor_function

--- a/polymorphic/tests/migrations/0001_initial.py
+++ b/polymorphic/tests/migrations/0001_initial.py
@@ -2028,4 +2028,38 @@ class Migration(migrations.Migration):
             options={"abstract": False, "base_manager_name": "objects"},
             bases=("tests.subclassselectorproxymodel",),
         ),
+        migrations.CreateModel(
+            name="NonPolymorphicParent",
+            fields=[
+                (
+                    "group_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="auth.Group",
+                    ),
+                ),
+                (
+                    "polymorphic_ctype",
+                    models.ForeignKey(
+                        editable=False,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="polymorphic_tests.nonpolymorphicparent_set+",
+                        to="contenttypes.ContentType",
+                    ),
+                ),
+                (
+                    "test",
+                    models.CharField(
+                        max_length=255, default="test_non_polymorphic_parent"
+                    ),
+                ),
+            ],
+            options={"abstract": False, "base_manager_name": "objects",},
+            bases=("auth.group", models.Model),
+        ),
     ]

--- a/polymorphic/tests/models.py
+++ b/polymorphic/tests/models.py
@@ -2,6 +2,7 @@
 import uuid
 
 import django
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.query import QuerySet
@@ -500,3 +501,7 @@ class SubclassSelectorProxyModel(SubclassSelectorProxyBaseModel):
 
 class SubclassSelectorProxyConcreteModel(SubclassSelectorProxyModel):
     concrete_field = models.CharField(max_length=10, default="test_cf")
+
+
+class NonPolymorphicParent(PolymorphicModel, Group):
+    test = models.CharField(max_length=22, default="test_non_polymorphic_parent")

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -50,6 +50,7 @@ from polymorphic.tests.models import (
     MultiTableDerived,
     MyManager,
     MyManagerQuerySet,
+    NonPolymorphicParent,
     NonProxyChild,
     One2OneRelatingModel,
     One2OneRelatingModelDerived,
@@ -1242,3 +1243,8 @@ class PolymorphicTests(TransactionTestCase):
 
         obj.refresh_from_db(fields=["field1"])
         assert obj.field1 == "aa1"
+
+    def test_non_polymorphic_parent(self):
+
+        obj = NonPolymorphicParent.objects.create()
+        assert obj.delete()


### PR DESCRIPTION
Hello Folks, 

Here is my proposal to fix #9. 

When we have a PolymorphicModel with a non-polymorphic parent, deleting the parent is missing `_base_objects`. This pull-requests ads a fallback to `objects` when `_base_objects` is None. 

Cheers! 
