### PR TITLE
Got rid of `RemovedInDjango40Warning` warnings mentioned in #424

### DIFF
--- a/example/orders/models.py
+++ b/example/orders/models.py
@@ -1,7 +1,11 @@
+import django
 from django.db import models
 from django.utils.dates import MONTHS_3
 from django.utils.six import python_2_unicode_compatible
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION > (3, ):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 from polymorphic.models import PolymorphicModel
 

--- a/polymorphic/admin/childadmin.py
+++ b/polymorphic/admin/childadmin.py
@@ -3,9 +3,13 @@ The child admin displays the change/delete view of the subclass model.
 """
 import inspect
 
+import django
 from django.contrib import admin
 from django.urls import resolve
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION > (3, ):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 from polymorphic.utils import get_base_polymorphic_model
 

--- a/polymorphic/admin/filters.py
+++ b/polymorphic/admin/filters.py
@@ -1,6 +1,10 @@
+import django
 from django.contrib import admin
 from django.core.exceptions import PermissionDenied
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION > (3, ):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 
 class PolymorphicChildModelFilter(admin.SimpleListFilter):

--- a/polymorphic/admin/forms.py
+++ b/polymorphic/admin/forms.py
@@ -1,6 +1,10 @@
+import django
 from django import forms
 from django.contrib.admin.widgets import AdminRadioSelect
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION > (3, ):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 
 class PolymorphicModelChoiceForm(forms.Form):

--- a/polymorphic/admin/helpers.py
+++ b/polymorphic/admin/helpers.py
@@ -5,10 +5,14 @@ This makes sure that admin fieldsets/layout settings are exported to the templat
 """
 import json
 
+import django
 from django.contrib.admin.helpers import AdminField, InlineAdminForm, InlineAdminFormSet
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
-from django.utils.translation import ugettext
+if django.VERSION > (3, ):
+    from django.utils.translation import gettext
+else:
+    from django.utils.translation import ugettext as gettext
 
 from polymorphic.formsets import BasePolymorphicModelFormSet
 
@@ -96,7 +100,7 @@ class PolymorphicInlineAdminFormSet(InlineAdminFormSet):
                 "name": "#%s" % self.formset.prefix,
                 "options": {
                     "prefix": self.formset.prefix,
-                    "addText": ugettext("Add another %(verbose_name)s")
+                    "addText": gettext("Add another %(verbose_name)s")
                     % {"verbose_name": capfirst(verbose_name)},
                     "childTypes": [
                         {
@@ -105,7 +109,7 @@ class PolymorphicInlineAdminFormSet(InlineAdminFormSet):
                         }
                         for model in self.formset.child_forms.keys()
                     ],
-                    "deleteText": ugettext("Remove"),
+                    "deleteText": gettext("Remove"),
                 },
             }
         )

--- a/polymorphic/admin/parentadmin.py
+++ b/polymorphic/admin/parentadmin.py
@@ -3,6 +3,7 @@ The parent admin displays the list view of the base model.
 """
 import sys
 
+import django
 from django.contrib import admin
 from django.contrib.admin.helpers import AdminErrorList, AdminForm
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
@@ -14,7 +15,10 @@ from django.template.response import TemplateResponse
 from django.utils.encoding import force_text
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+if django.VERSION > (3, ):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 from polymorphic.utils import get_base_polymorphic_model
 

--- a/polymorphic/templatetags/polymorphic_formset_tags.py
+++ b/polymorphic/templatetags/polymorphic_formset_tags.py
@@ -1,9 +1,13 @@
 import json
 
+import django
 from django.template import Library
 from django.utils.encoding import force_text
 from django.utils.text import capfirst
-from django.utils.translation import ugettext
+if django.VERSION > (3, ):
+    from django.utils.translation import gettext
+else:
+    from django.utils.translation import ugettext as gettext
 
 from polymorphic.formsets import BasePolymorphicModelFormSet
 
@@ -44,10 +48,10 @@ def as_script_options(formset):
         "prefix": formset.prefix,
         "pkFieldName": formset.model._meta.pk.name,
         "addText": getattr(formset, "add_text", None)
-        or ugettext("Add another %(verbose_name)s")
+        or gettext("Add another %(verbose_name)s")
         % {"verbose_name": capfirst(verbose_name)},
         "showAddButton": getattr(formset, "show_add_button", True),
-        "deleteText": ugettext("Delete"),
+        "deleteText": gettext("Delete"),
     }
 
     if isinstance(formset, BasePolymorphicModelFormSet):


### PR DESCRIPTION
Silenced

```
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```

warnings from django 3 mentioned in #424 . Should still work for Django2.

tox fails with the same errors as a clean clone from the repository.