### PR TITLE
Corrected import location

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -8,7 +8,7 @@ import copy
 from collections import defaultdict
 
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models.query import ModelIterable, Q, QuerySet
 
 from . import compat


### PR DESCRIPTION
I noticed this import was pointing to the wrong location when it was called out after I upgraded to django 3.1. Looking at query.py, it imports the FieldDoesNotExist exception from django.db.models, rather than from django.core.exceptions, where FieldDoesNotExist is actually defined.

In the past, django.db.models had a reference to FieldDoesNotExist, so importing from that location was not an issue, but at some point in the past that reference was removed, so the import fails.