### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,33 @@ matrix:
     - { env: TOXENV=py37-djangomaster, python: 3.7 }
     - { env: TOXENV=py38-djangomaster, python: 3.8 }
     - { env: TOXENV=py38-djangomaster-postgres DB=postgres, python: 3.8 }
+    # Adding jobs for ppc64le architecture
+    # Django 2.1: Python 3.5, 3.6, or 3.7
+    - { env: TOXENV=py35-django21, python: 3.5, arch: ppc64le }
+    - { env: TOXENV=py36-django21, python: 3.6, arch: ppc64le }
+    - { env: TOXENV=py37-django21, python: 3.7, arch: ppc64le }
+    - { env: TOXENV=py37-django21-postgres DB=postgres, python: 3.7, arch: ppc64le }
+    # Django 2.2: Python 3.5, 3.6, 3.7 or 3.8
+    - { env: TOXENV=py35-django22, python: 3.5, arch: ppc64le }
+    - { env: TOXENV=py36-django22, python: 3.6, arch: ppc64le }
+    - { env: TOXENV=py37-django22, python: 3.7, arch: ppc64le }
+    - { env: TOXENV=py38-django22, python: 3.8, arch: ppc64le }
+    - { env: TOXENV=py38-django22-postgres DB=postgres, python: 3.8, arch: ppc64le }
+    # Django 3.0: Python 3.6, 3.7 or 3.8
+    - { env: TOXENV=py36-django30, python: 3.6, arch: ppc64le }
+    - { env: TOXENV=py37-django30, python: 3.7, arch: ppc64le }
+    - { env: TOXENV=py38-django30, python: 3.8, arch: ppc64le }
+    - { env: TOXENV=py38-django30-postgres DB=postgres, python: 3.8, arch: ppc64le }
+    # Django 3.1: Python 3.6, 3.7 or 3.8
+    - { env: TOXENV=py36-django31, python: 3.6, arch: ppc64le }
+    - { env: TOXENV=py37-django31, python: 3.7, arch: ppc64le }
+    - { env: TOXENV=py38-django31, python: 3.8, arch: ppc64le }
+    - { env: TOXENV=py38-django31-postgres DB=postgres, python: 3.8, arch: ppc64le }
+    # Django development master (direct from GitHub source):
+    - { env: TOXENV=py36-djangomaster, python: 3.6, arch: ppc64le }
+    - { env: TOXENV=py37-djangomaster, python: 3.7, arch: ppc64le }
+    - { env: TOXENV=py38-djangomaster, python: 3.8, arch: ppc64le }
+    - { env: TOXENV=py38-djangomaster-postgres DB=postgres, python: 3.8, arch: ppc64le }
 
   allow_failures:
     - env: TOXENV=py36-djangomaster


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-polymorphic/builds/189011390

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj