### PR TITLE
Fix #474 - FilteredRelation usage

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from django import get_version as get_django_version
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
+from django.db.models import FilteredRelation
 from django.db.models.query import ModelIterable, Q, QuerySet
 
 from .query_translate import (
@@ -265,6 +266,8 @@ class PolymorphicQuerySet(QuerySet):
             # stored inside a complex query expression.
             if isinstance(a, Q):
                 translate_polymorphic_Q_object(self.model, a)
+            elif isinstance(a, FilteredRelation):
+                patch_lookup(a.condition)
             elif hasattr(a, "get_source_expressions"):
                 for source_expression in a.get_source_expressions():
                     if source_expression is not None:
@@ -290,6 +293,8 @@ class PolymorphicQuerySet(QuerySet):
                             tree_node_test___lookup(my_model, child)
 
                 tree_node_test___lookup(self.model, a)
+            elif isinstance(a, FilteredRelation):
+                test___lookup(a.condition)
             elif hasattr(a, "get_source_expressions"):
                 for source_expression in a.get_source_expressions():
                     test___lookup(source_expression)

--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -293,8 +293,6 @@ class PolymorphicQuerySet(QuerySet):
                             tree_node_test___lookup(my_model, child)
 
                 tree_node_test___lookup(self.model, a)
-            elif isinstance(a, FilteredRelation):
-                test___lookup(a.condition)
             elif hasattr(a, "get_source_expressions"):
                 for source_expression in a.get_source_expressions():
                     test___lookup(source_expression)

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -1097,6 +1097,14 @@ class PolymorphicTests(TransactionTestCase):
         ).aggregate(count=Count("info_joined"))
         self.assertEqual(result, {"count": 2})
 
+        # We should get a BlogA and a BlogB
+        result = BlogBase.objects.annotate(
+            info_joined=FilteredRelation("bloga", condition=Q(BlogA___info__contains="joined")),
+        ).filter(info_joined__isnull=True)
+        self.assertEqual(result.count(), 2)
+        self.assertIsInstance(result.first(), BlogA)
+        self.assertIsInstance(result.last(), BlogB)
+
     def test_polymorphic__expressions(self):
 
         from django.db.models.functions import Concat


### PR DESCRIPTION
Using FilteredRelation breaks django-polymorphic.

Hope this helps.

https://github.com/django-polymorphic/django-polymorphic/issues/474