### PR TITLE
Allow for kwargs to be passed to bulk_create

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -132,11 +132,11 @@ class PolymorphicQuerySet(QuerySet):
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)
 
-    def bulk_create(self, objs, batch_size=None):
+    def bulk_create(self, objs, **kwargs):
         objs = list(objs)
         for obj in objs:
             obj.pre_save_polymorphic()
-        return super(PolymorphicQuerySet, self).bulk_create(objs, batch_size)
+        return super(PolymorphicQuerySet, self).bulk_create(objs, **kwargs)
 
     def non_polymorphic(self):
         """switch off polymorphic behaviour for this query.

--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -132,11 +132,11 @@ class PolymorphicQuerySet(QuerySet):
     as_manager.queryset_only = True
     as_manager = classmethod(as_manager)
 
-    def bulk_create(self, objs, **kwargs):
+    def bulk_create(self, objs, batch_size=None, ignore_conflicts=False):
         objs = list(objs)
         for obj in objs:
             obj.pre_save_polymorphic()
-        return super(PolymorphicQuerySet, self).bulk_create(objs, **kwargs)
+        return super(PolymorphicQuerySet, self).bulk_create(objs, batch_size, ignore_conflicts)
 
     def non_polymorphic(self):
         """switch off polymorphic behaviour for this query.


### PR DESCRIPTION
# Overview
This simple pull requests converts the `batch_size` parameter on the `bulk_create` method into `**kwargs`. Django supports two keyword arguments: `batch_size` and `ignore_conflicts`, the latter of which was added with Django 2.2.

The `ignore_conflicts` parameter instructs supported databases to ignore the failure to insert rows that fail constraints. This is especially useful if you're running `bulk_create` with a large number of objects that may or may not exist.

# Testing
I've added two tests; one with the `ignore_conflicts` set to `True` and one with it set to `False`. I'm checking to see whether the insertion happens when one object exists and one does not.

# Potential Pitfalls?
I decided to go with `bulk_create(self, objs, **kwargs)` instead of `bulk_create(self, objs, batch_size=None, ignore_errors=False)` to make it a little bit more flexible if Django decides to implement more functionality. However, by going the less explicit route, I suppose there is potential for Django to implement a keyword that would break this? I'm not sure of the likelihood of this, and what this community's stance on that would be.

# Other Items
This is my first pull request to a public repository, so I'm sorry if I missed anything or got the format wrong. As such, I'm very open to suggestions and corrections. I'll be the first to admit that I don't know what I don't know, and if you can point out my mistakes I can learn from them. I appreciate all of the work that this entire community has done, and I look forward to the continued development of this project.

Thanks for your consideration.
