### PR TITLE
Django 4.0a compatibility

### DIFF
--- a/polymorphic/admin/helpers.py
+++ b/polymorphic/admin/helpers.py
@@ -6,7 +6,7 @@ This makes sure that admin fieldsets/layout settings are exported to the templat
 import json
 
 from django.contrib.admin.helpers import AdminField, InlineAdminForm, InlineAdminFormSet
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import capfirst
 from django.utils.translation import gettext
 
@@ -101,7 +101,7 @@ class PolymorphicInlineAdminFormSet(InlineAdminFormSet):
                     "childTypes": [
                         {
                             "type": model._meta.model_name,
-                            "name": force_text(model._meta.verbose_name),
+                            "name": force_str(model._meta.verbose_name),
                         }
                         for model in self.formset.child_forms.keys()
                     ],

--- a/polymorphic/admin/parentadmin.py
+++ b/polymorphic/admin/parentadmin.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import URLResolver
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
@@ -313,9 +313,9 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
 
         extra_qs = ""
         if request.META["QUERY_STRING"]:
-            # QUERY_STRING is bytes in Python 3, using force_text() to decode it as string.
+            # QUERY_STRING is bytes in Python 3, using force_str() to decode it as string.
             # See QueryDict how Django deals with that.
-            extra_qs = "&{0}".format(force_text(request.META["QUERY_STRING"]))
+            extra_qs = "&{0}".format(force_str(request.META["QUERY_STRING"]))
 
         choices = self.get_child_type_choices(request, "add")
         if len(choices) == 1:
@@ -340,7 +340,7 @@ class PolymorphicParentModelAdmin(admin.ModelAdmin):
         opts = self.model._meta
 
         context = {
-            "title": _("Add %s") % force_text(opts.verbose_name),
+            "title": _("Add %s") % force_str(opts.verbose_name),
             "adminform": adminForm,
             "is_popup": ("_popup" in request.POST or "_popup" in request.GET),
             "media": mark_safe(media),

--- a/polymorphic/templatetags/polymorphic_formset_tags.py
+++ b/polymorphic/templatetags/polymorphic_formset_tags.py
@@ -1,7 +1,7 @@
 import json
 
 from django.template import Library
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.text import capfirst
 from django.utils.translation import gettext
 
@@ -54,7 +54,7 @@ def as_script_options(formset):
         # Allow to add different types
         options["childTypes"] = [
             {
-                "name": force_text(model._meta.verbose_name),
+                "name": force_str(model._meta.verbose_name),
                 "type": model._meta.model_name,
             }
             for model in formset.child_forms.keys()


### PR DESCRIPTION
Use force_str instead of force_text (deprecated in Django 3.2, removed in Django 4.0)