### PR TITLE
Add css dark mode to polymorphic_inlines.css

### DIFF
--- a/polymorphic/static/polymorphic/css/polymorphic_inlines.css
+++ b/polymorphic/static/polymorphic/css/polymorphic_inlines.css
@@ -32,3 +32,10 @@
   /* needed for grapelli, which uses grp-empty-form */
   display: none;
 }
+
+@media (prefers-color-scheme: dark) {
+  .polymorphic-type-menu {
+    border: 1px solid #121212;
+    background-color: #212121;
+  }
+}


### PR DESCRIPTION
**Problem**

Polymorphic menu are light in dark mode. Here is a screenshot I am attaching.

![Screenshot 2022-02-12 002055](https://user-images.githubusercontent.com/59503233/153654331-7ba6a50e-c255-4612-9cc8-03b8b81dda92.png)

**Solution**

Updated polymorphic_inlines.css to override colors using the 'prefers-color-scheme: dark' media query.

This is a screenshot after changes are done.

![Screenshot 2022-02-12 002653](https://user-images.githubusercontent.com/59503233/153654495-7758ab07-e6b6-4afd-8baf-87436888c98c.png)

