### PR TITLE
Caching in ingeritance accessor functions

### DIFF
--- a/polymorphic/models.py
+++ b/polymorphic/models.py
@@ -197,11 +197,15 @@ class PolymorphicModel(with_metaclass(PolymorphicModelBase, models.Model)):
             return
         self.__class__.polymorphic_super_sub_accessors_replaced = True
 
-        def create_accessor_function_for_model(model, accessor_name):
+        def create_accessor_function_for_model(model, field):
             def accessor_function(self):
-                objects = getattr(model, "_base_objects", model.objects)
-                attr = objects.get(pk=self.pk)
-                return attr
+                try:
+                    rel_obj = field.get_cached_value(self)
+                except KeyError:
+                    objects = getattr(model, "_base_objects", model.objects)
+                    rel_obj = objects.get(pk=self.pk)
+                    field.set_cached_value(self, rel_obj)
+                return rel_obj
 
             return accessor_function
 
@@ -214,10 +218,14 @@ class PolymorphicModel(with_metaclass(PolymorphicModelBase, models.Model)):
                 type(orig_accessor),
                 (ReverseOneToOneDescriptor, ForwardManyToOneDescriptor),
             ):
+
+                field = orig_accessor.related \
+                    if isinstance(orig_accessor, ReverseOneToOneDescriptor) else orig_accessor.field
+
                 setattr(
                     self.__class__,
                     name,
-                    property(create_accessor_function_for_model(model, name)),
+                    property(create_accessor_function_for_model(model, field)),
                 )
 
     def _get_inheritance_relation_fields_and_models(self):

--- a/polymorphic/tests/test_orm.py
+++ b/polymorphic/tests/test_orm.py
@@ -985,6 +985,29 @@ class PolymorphicTests(TransactionTestCase):
         # test that we can delete the object
         t.delete()
 
+    def test_polymorphic__accessor_caching(self):
+        blog_a = BlogA.objects.create(name="blog")
+
+        blog_base = BlogBase.objects.non_polymorphic().get(id=blog_a.id)
+        blog_a = BlogA.objects.get(id=blog_a.id)
+
+        # test reverse accessor & check that we get back cached object on repeated access
+        self.assertEqual(blog_base.bloga, blog_a)
+        self.assertIs(blog_base.bloga, blog_base.bloga)
+        cached_blog_a = blog_base.bloga
+
+        # test forward accessor & check that we get back cached object on repeated access
+        self.assertEqual(blog_a.blogbase_ptr, blog_base)
+        self.assertIs(blog_a.blogbase_ptr, blog_a.blogbase_ptr)
+        cached_blog_base = blog_a.blogbase_ptr
+
+        # check that refresh_from_db correctly clears cached related objects
+        blog_base.refresh_from_db()
+        blog_a.refresh_from_db()
+
+        self.assertIsNot(cached_blog_a, blog_base.bloga)
+        self.assertIsNot(cached_blog_base, blog_a.blogbase_ptr)
+
     def test_polymorphic__aggregate(self):
         """test ModelX___field syntax on aggregate (should work for annotate either)"""
 


### PR DESCRIPTION
The accessor functions for inheritance relations are overwritten in PolymorphicModel. This also disables the caching usually provided by django, creating multiple redundant SQL queries in certain situations:
```
parent = Parent.object.get(id=1)
c1 = parent.child  # retrieves child from db
c2 = parent.child  # retrieves child from db again!
```
This contradicts the default django behavior and can cause unnecessary overhead.

This PR fixes that issue by using the caching mechanism of the underlying field.
The new unit test `test_polymorphic__accessor_caching` validates this new feature.