### PR TITLE
Don't raise exceptions for users with version conflicts

### DIFF
--- a/polymorphic/__init__.py
+++ b/polymorphic/__init__.py
@@ -6,9 +6,5 @@ This code and affiliated files are (C) by Bert Constantin and individual contrib
 Please see LICENSE and AUTHORS for more information.
 """
 
-import pkg_resources
 
-try:
-    __version__ = pkg_resources.require("django-polymorphic")[0].version
-except pkg_resources.DistributionNotFound:
-    __version__ = None  # for RTD among others
+__version__ = "3.1.0"


### PR DESCRIPTION
Some users may have version conflicts, so I think it might help to just set the version explicitly, instead of dynamically. Another option would be to catch the `ContextualVersionConflict` error in addition to the already-caught error and log a warning, but I slightly prefer this more standard approach at the cost of a little more manual work for each release.