### PR TITLE
Support select_related and prefetch_related for inherited models

### DIFF
--- a/polymorphic/query.py
+++ b/polymorphic/query.py
@@ -122,6 +122,7 @@ class PolymorphicQuerySet(QuerySet):
             copy.copy(self.polymorphic_deferred_loading[0]),
             self.polymorphic_deferred_loading[1],
         )
+        new._polymorphic_select_related = copy.copy(self._polymorphic_select_related)
         return new
 
     def as_manager(cls):


### PR DESCRIPTION
add `select_polymorphic_related` and `prefetch_polymorphic_related` methods for select and prefetch on inherited models

Triggers Django errors when that field doesn't exist in a particular subclass

Example works exactly same as django select_related and prefetch_related
```python
queryset = Project.objects.select_polymorphic_related(
    ArtProject, 'artist', 'canvas__painter'
).select_polymorphic_related(
    ResearchProject, 'supervisor',
)


queryset = Project.objects.prefetch_polymorphic_related(
    ArtProject, 'artist', Prefetch('canvas', queryset=Project.objects.annotate(size=F('width') * F('height')))
).prefetch_polymorphic_related(
    ResearchProject, 'authors',
)
```