### PR TITLE
Fix multi-fields in single line

### DIFF
--- a/polymorphic/admin/childadmin.py
+++ b/polymorphic/admin/childadmin.py
@@ -227,7 +227,15 @@ class PolymorphicChildModelAdmin(admin.ModelAdmin):
 
         # Find which fields are not part of the common fields.
         for fieldset in self.get_base_fieldsets(request, obj):
-            for field in fieldset[1]["fields"]:
+            # multiple elements in single line
+            if isinstance(field, tuple):
+                for line_field in field:
+                    try:
+                        subclass_fields.remove(line_field)
+                    except ValueError:
+                        pass  # field not found in form, Django will raise exception later.
+            else:
+                # regular one-element-per-line
                 try:
                     subclass_fields.remove(field)
                 except ValueError:


### PR DESCRIPTION
As [Django documentation](https://docs.djangoproject.com/en/4.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.fieldsets) states, you may use:

```python
{
    "fields": [("first_name", "last_name"), "address", "city", "state"],
}

```

to specify that `first_name` and `last_name` should be displayed in single line.

Django Polymorphic though wasn't able to work with this syntax properly as it tried to remove whole tuple instead of individual elements from child fields.

This PR fixes this, and now multi-field lines are rendered correctly.