### PR TITLE
Removed usage of deprecated pkg_resources

### DIFF
--- a/polymorphic/__init__.py
+++ b/polymorphic/__init__.py
@@ -6,9 +6,7 @@ This code and affiliated files are (C) by Bert Constantin and individual contrib
 Please see LICENSE and AUTHORS for more information.
 """
 
-import pkg_resources
+VERSION = "3.1.0"
 
-try:
-    __version__ = pkg_resources.require("django-polymorphic")[0].version
-except pkg_resources.DistributionNotFound:
-    __version__ = None  # for RTD among others
+# version synonym for backwards compatibility
+__version__ = VERSION

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-polymorphic
-version = 3.1.0
+version = attr: polymorphic.VERSION
 description = Seamless polymorphic inheritance for Django models
 long_description = file:README.rst
 author = Bert Constantin


### PR DESCRIPTION
Fixes #503 

`pkg_resources` is deprecated and should not be used anymore. We encountered this in our CI see https://github.com/django-json-api/django-rest-framework-json-api/pull/1146

The version is now defined in `polymorphic/__init__.py` and `setup.py` extracts it from there. This way, there is also no need for setuptools to be installed when using django polymorphic.